### PR TITLE
使getkey可返回key_msg_char型的消息

### DIFF
--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -354,7 +354,7 @@ kbmsg() {
 	struct _graph_setting * pg = &graph_setting;
 	if (pg->exit_window)
 		return grNoInitGraph;
-	return peekallkey(pg, 1);
+	return peekallkey(pg, 3);
 }
 
 int


### PR DESCRIPTION
原`kbmsg`函数调用`peekallkey`时过滤了`key_msg_char`消息且未把它重新放入队列，现传入`flags`=3（相当于`KEYMSG_DOWN_FLAG|KEYMSG_CHAR_FLAG`），可处理`WM_CHAR`消息。
另外，由于默认采用`DefWindowProc`处理消息，故不用专门处理`WM_IME_CHAR`消息，`DefWindowProc`会把它转译成`WM_CHAR`消息。