### PR TITLE
修复了putimage_xxx系列函数的相关问题

### DIFF
--- a/src/image.cpp
+++ b/src/image.cpp
@@ -838,7 +838,10 @@ fix_rect_1size(
 	int* nHeightSrc      // height of source rectangle
 	)
 {
-	struct viewporttype _vpt = {0, 0, pdest->m_width, pdest->m_height};
+	/* prepare viewport region and carry out coordinate transformation */
+	struct viewporttype _vpt = pdest->m_vpt;
+	*nXOriginDest += _vpt.left;
+	*nYOriginDest += _vpt.top;
 	/* default value proc */
 	if (*nWidthSrc == 0) {
 		*nWidthSrc  = psrc->m_width;


### PR DESCRIPTION
#4 中的问题来自image.cpp中`fix_rect_1size`函数总是认为剪裁区域是全图像，且没有按EGE库的要求（执行setviewport后原点改变）转换坐标，现已修复。
建议设置单独的`setorigin`和`setcliprgn`函数，使裁剪区域与绘图坐标转换相对独立