### PR TITLE
修复计算绘制区时计算失误

### DIFF
--- a/src/image.cpp
+++ b/src/image.cpp
@@ -880,11 +880,11 @@ fix_rect_1size(
 		*nHeightSrc      -= dy;
 	}
 	if (*nXOriginDest + *nWidthSrc > _vpt.right) {
-		int dx = *nXOriginDest + *nWidthSrc - _vpt.right + 1;
+		int dx = *nXOriginDest + *nWidthSrc - _vpt.right;
 		*nWidthSrc -= dx;
 	}
 	if (*nYOriginDest + *nHeightSrc > _vpt.bottom) {
-		int dy = *nYOriginDest + *nHeightSrc - _vpt.bottom + 1;
+		int dy = *nYOriginDest + *nHeightSrc - _vpt.bottom;
 		*nHeightSrc -= dy;
 	}
 }


### PR DESCRIPTION
当源图像的绘制部分超出目标的裁剪区时，EGE 在计算实际绘制区域时会少
算 1 行和 1 列。

复现代码：
```c++
#include "ege.h"
int main()
{
	ege::initgraph(600, 400);
	ege::setbkcolor(ege::YELLOW);

	ege::PIMAGE rect = ege::newimage();
	ege::resize(rect, 200, 200);
	ege::setbkcolor_f(ege::BLUE, rect);
	ege::cleardevice(rect);

	ege::putimage_alphablend(NULL, rect, 500, 300, 255);

	ege::getch();
	ege::closegraph();
	return 0;
}
```
运行结果：
![图片](https://user-images.githubusercontent.com/31474766/77064788-1b208a00-6a1b-11ea-9e15-5747e62a34ad.png)

可见最右列和最底行仍然是背景色黄色