### PR TITLE
修复两个颜色相关 bug

### DIFF
--- a/src/ege.h
+++ b/src/ege.h
@@ -161,7 +161,6 @@
 
 #define SHOWCONSOLE             1       // 进入图形模式时，保留控制台的显示
 #define RGBTOBGR(color)         ((((color) & 0xFF) << 16) | (((color) & 0xFF0000) >> 16) | ((color) & 0xFF00FF00))
-#define BGRTORGB(color)         ((((color) & 0xFF) << 16) | (((color) & 0xFF0000) >> 16) | ((color) & 0xFF00FF00))
 #define EGERGB(r, g, b)         ( ((r)<<16) | ((g)<<8) | (b))
 #define EGERGBA(r, g, b, a)     ( ((r)<<16) | ((g)<<8) | (b) | ((a)<<24) )
 #define EGEARGB(a, r, g, b)     ( ((r)<<16) | ((g)<<8) | (b) | ((a)<<24) )

--- a/src/ege.h
+++ b/src/ege.h
@@ -161,6 +161,7 @@
 
 #define SHOWCONSOLE             1       // 进入图形模式时，保留控制台的显示
 #define RGBTOBGR(color)         ((((color) & 0xFF) << 16) | (((color) & 0xFF0000) >> 16) | ((color) & 0xFF00FF00))
+#define BGRTORGB(color)         ((((color) & 0xFF) << 16) | (((color) & 0xFF0000) >> 16) | ((color) & 0xFF00FF00))
 #define EGERGB(r, g, b)         ( ((r)<<16) | ((g)<<8) | (b))
 #define EGERGBA(r, g, b, a)     ( ((r)<<16) | ((g)<<8) | (b) | ((a)<<24) )
 #define EGEARGB(a, r, g, b)     ( ((r)<<16) | ((g)<<8) | (b) | ((a)<<24) )

--- a/src/egegapi.cpp
+++ b/src/egegapi.cpp
@@ -335,7 +335,7 @@ getpixel(int x, int y, PIMAGE pimg) {
 		return 0;
 	}
 	color_t col = img->m_pBuffer[y * img->m_width + x];
-	return col;
+	return BGRTORGB(col);
 }
 
 void
@@ -346,7 +346,7 @@ putpixel(int x, int y, color_t color, PIMAGE pimg) {
 	if ((x < 0) || (y < 0) || (x >= img->m_vpt.right) || (y >= img->m_vpt.bottom)) {
 		;
 	} else {
-		img->m_pBuffer[y * img->m_width + x] = color;
+		img->m_pBuffer[y * img->m_width + x] = RGBTOBGR(color);
 	}
 	CONVERT_IMAGE_END;
 }
@@ -385,13 +385,13 @@ color_t
 getpixel_f(int x, int y, PIMAGE pimg) {
 	PIMAGE img = CONVERT_IMAGE_F_CONST(pimg);
 	color_t col = img->m_pBuffer[y * img->m_width + x];
-	return col;
+	return BGRTORGB(col);
 }
 
 void
 putpixel_f(int x, int y, color_t color, PIMAGE pimg) {
 	PIMAGE img = CONVERT_IMAGE_F(pimg);
-	img->m_pBuffer[y * img->m_width + x] = color;
+	img->m_pBuffer[y * img->m_width + x] = RGBTOBGR(color);
 }
 
 void

--- a/src/egegapi.cpp
+++ b/src/egegapi.cpp
@@ -335,7 +335,7 @@ getpixel(int x, int y, PIMAGE pimg) {
 		return 0;
 	}
 	color_t col = img->m_pBuffer[y * img->m_width + x];
-	return BGRTORGB(col);
+	return col;
 }
 
 void
@@ -346,7 +346,7 @@ putpixel(int x, int y, color_t color, PIMAGE pimg) {
 	if ((x < 0) || (y < 0) || (x >= img->m_vpt.right) || (y >= img->m_vpt.bottom)) {
 		;
 	} else {
-		img->m_pBuffer[y * img->m_width + x] = RGBTOBGR(color);
+		img->m_pBuffer[y * img->m_width + x] = color;
 	}
 	CONVERT_IMAGE_END;
 }
@@ -363,7 +363,7 @@ putpixels(int nPoint, int* pPoints, PIMAGE pimg) {
 		if ((x < 0) || (y < 0) || (x >= w) || (y >= h)) {
 			;
 		} else {
-			pb[y * tw + x] = RGBTOBGR(c);
+			pb[y * tw + x] = c;
 		}
 	}
 	CONVERT_IMAGE_END;
@@ -376,7 +376,7 @@ putpixels_f(int nPoint, int* pPoints, PIMAGE pimg) {
 	int tw = img->m_width;
 	for (int n=0; n<nPoint; ++n, pPoints += 3) {
 		c = pPoints[2];
-		img->m_pBuffer[pPoints[1] * tw + pPoints[0]] = RGBTOBGR(c);
+		img->m_pBuffer[pPoints[1] * tw + pPoints[0]] = c;
 	}
 	CONVERT_IMAGE_END;
 }
@@ -385,13 +385,13 @@ color_t
 getpixel_f(int x, int y, PIMAGE pimg) {
 	PIMAGE img = CONVERT_IMAGE_F_CONST(pimg);
 	color_t col = img->m_pBuffer[y * img->m_width + x];
-	return BGRTORGB(col);
+	return col;
 }
 
 void
 putpixel_f(int x, int y, color_t color, PIMAGE pimg) {
 	PIMAGE img = CONVERT_IMAGE_F(pimg);
-	img->m_pBuffer[y * img->m_width + x] = RGBTOBGR(color);
+	img->m_pBuffer[y * img->m_width + x] = color;
 }
 
 void

--- a/src/egegapi.cpp
+++ b/src/egegapi.cpp
@@ -1902,10 +1902,7 @@ clearviewport(PIMAGE pimg) {
 			img->m_vpt.right - img->m_vpt.left,
 			img->m_vpt.bottom - img->m_vpt.top
 		};
-		HBRUSH hbr_c = (HBRUSH)GetCurrentObject(img->m_hDC, OBJ_BRUSH);
-		LOGBRUSH logBrush;
-		GetObject(hbr_c, sizeof(logBrush), &logBrush);
-		HBRUSH hbr = CreateSolidBrush(logBrush.lbColor);
+		HBRUSH hbr = CreateSolidBrush(GetBkColor(img->m_hDC));
 		FillRect(img->m_hDC, &rect, hbr);
 		DeleteObject(hbr);
 	}


### PR DESCRIPTION
#11 中：

> putpixels和putpixels_f像素颜色赋值方式修正，由BGR改为RGB

> clearviewport清除视口区域是直接用bar糊上去的，这样颜色实际是填充颜色，建议修正为用背景颜色填充。

请 @GWMforget1997 测试
