### PR TITLE
自定义窗口图标和创建 UNICODE 窗口

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,3 @@
-/include
-/*.bat
-/demo
-/lib
-/doc
-/vc6
 .vs/
 *.tlog
 *.obj
@@ -12,8 +6,6 @@
 *.VC.db
 *.user
 *.o
-build/
-
-/src
+/build
 .idea/
 *-build-*

--- a/src/ege.h
+++ b/src/ege.h
@@ -345,6 +345,7 @@ enum initmode_flag {
 	INIT_TOPMOST        = 0x4,
 	INIT_RENDERMANUAL   = 0x8,
 	INIT_NOFORCEEXIT    = 0x10,
+	INIT_UNICODE        = 0x20,
 	INIT_WITHLOGO       = 0x100,
 #if defined(_DEBUG) || defined(DEBUG)
 	INIT_DEFAULT    = 0x0,

--- a/src/ege.h
+++ b/src/ege.h
@@ -663,6 +663,7 @@ void EGEAPI closegraph();                                      // 关闭图形环境
 bool EGEAPI is_run();   // 判断UI是否退出
 void EGEAPI setcaption(LPCSTR  caption);
 void EGEAPI setcaption(LPCWSTR caption);
+void EGEAPI seticon(int icon_id);
 
 void EGEAPI movewindow(int x, int y, bool redraw = true);	//移动窗口
 void EGEAPI resizewindow(int width, int height);			//重设窗口尺寸

--- a/src/ege_head.h
+++ b/src/ege_head.h
@@ -340,6 +340,7 @@ public:
 // 定义ege全局状态对象
 struct _graph_setting {
 	bool has_init;
+	bool is_unicode;
 
 	struct _graph {
 		int width;
@@ -484,6 +485,9 @@ private:
 	long* m_cnt;
 	//Mutex* m_mutex;
 };
+
+// convert wide string to multibyte string
+LPSTR w2mb(LPCWSTR wStr);
 
 } // namespace ege
 

--- a/src/ege_head.h
+++ b/src/ege_head.h
@@ -339,6 +339,8 @@ public:
 
 // 定义ege全局状态对象
 struct _graph_setting {
+	bool has_init;
+
 	struct _graph {
 		int width;
 		int height;
@@ -363,8 +365,9 @@ struct _graph_setting {
 
 	HINSTANCE instance;
 	HWND    hwnd;
-	TCHAR   window_class_name[32];
-	TCHAR   window_caption[128];
+	LPCWSTR window_class_name;
+	LPCWSTR window_caption;
+	HICON   window_hicon;
 	int     exit_flag;
 	int     exit_window;
 	int     update_mark_count; //更新标记

--- a/src/ege_head.h
+++ b/src/ege_head.h
@@ -23,6 +23,8 @@
 #  include "stdint.h"
 #endif
 
+#include <string>
+
 #define _GRAPH_LIB_BUILD_
 #include "ege.h"
 #include "thread_queue.h"
@@ -421,7 +423,7 @@ struct _graph_setting {
 	DWORD g_t_buff[1024 * 8];
 };
 
-extern struct _graph_setting& graph_setting;
+extern struct _graph_setting graph_setting;
 
 template<typename T>
 struct count_ptr {
@@ -487,7 +489,7 @@ private:
 };
 
 // convert wide string to multibyte string
-LPSTR w2mb(LPCWSTR wStr);
+std::string w2mb(LPCWSTR wStr);
 
 } // namespace ege
 

--- a/src/ege_head.h
+++ b/src/ege_head.h
@@ -368,8 +368,8 @@ struct _graph_setting {
 
 	HINSTANCE instance;
 	HWND    hwnd;
-	LPCWSTR window_class_name;
-	LPCWSTR window_caption;
+	std::wstring window_class_name;
+	std::wstring window_caption;
 	HICON   window_hicon;
 	int     exit_flag;
 	int     exit_window;

--- a/src/egegapi.cpp
+++ b/src/egegapi.cpp
@@ -104,6 +104,19 @@ setcaption(LPCWSTR caption) {
 	::SetWindowTextW(getHWnd(), caption);
 }
 
+
+void seticon(int icon_id) {
+	HICON hIcon = NULL;
+	if (icon_id == 0) {
+		hIcon = ::LoadIconW(NULL, (LPCWSTR)IDI_APPLICATION);
+	} else {
+		hIcon = ::LoadIconW(getHInstance(), MAKEINTRESOURCEW(icon_id));
+	}
+	if (hIcon) {
+		::SetClassLongPtrW(getHWnd(), GCLP_HICON, (LONG_PTR)hIcon);
+	}
+}
+
 void movewindow(int x, int y, bool redraw) {
 	::MoveWindow(getHWnd(), x, y, getwidth(), getheight(), redraw);
 }

--- a/src/egegapi.cpp
+++ b/src/egegapi.cpp
@@ -102,32 +102,23 @@ is_run() {
 	return true;
 }
 
-static void setcaption_move(LPCWSTR caption) {
+void setcaption(LPCSTR  caption) {
+	int bufsize = MultiByteToWideChar(CP_ACP, 0, caption, -1, NULL, 0);
+	if (bufsize) {
+		std::wstring new_caption(bufsize, L'\0');
+		MultiByteToWideChar(CP_ACP, 0, caption, -1, &new_caption[0], bufsize);
+		setcaption(new_caption.c_str());
+	}
+}
+
+void setcaption(LPCWSTR caption) {
 	struct _graph_setting * pg = &graph_setting;
 	if (pg->has_init) {
 		::SetWindowTextW(getHWnd(), caption);
 		::UpdateWindow(getHWnd()); // for vc6
 	}
 
-	if (pg->window_caption != NULL) {
-		delete [] const_cast<LPWSTR>(pg->window_caption);
-	}
 	pg->window_caption = caption;
-}
-
-void setcaption(LPCSTR  caption) {
-	int bufsize = MultiByteToWideChar(CP_ACP, 0, caption, -1, NULL, 0);
-	if (bufsize) {
-		WCHAR* new_caption = new WCHAR[bufsize];
-		MultiByteToWideChar(CP_ACP, 0, caption, -1, new_caption, bufsize);
-		setcaption_move(new_caption);
-	}
-}
-
-void setcaption(LPCWSTR caption) {
-	WCHAR* new_caption = new WCHAR[lstrlenW(caption) + 1];
-	lstrcpyW(new_caption, caption);
-	setcaption_move(new_caption);
 }
 
 

--- a/src/egegapi.cpp
+++ b/src/egegapi.cpp
@@ -34,10 +34,10 @@ void guiupdate(_graph_setting* pg, egeControlBase* &root);
 float _GetFPS(int add);
 int getflush();
 
-LPSTR w2mb(LPCWSTR wStr) {
+std::string w2mb(LPCWSTR wStr) {
 	int bufsize = WideCharToMultiByte(CP_ACP, 0, wStr, -1, NULL, 0, 0, 0);
-	CHAR* mbStr = new CHAR[bufsize];
-	WideCharToMultiByte(CP_ACP, 0, wStr, -1, mbStr, bufsize, 0, 0);
+	std::string mbStr(bufsize, '\0');
+	WideCharToMultiByte(CP_ACP, 0, wStr, -1, &mbStr[0], bufsize, 0, 0);
 	return mbStr;
 }
 

--- a/src/egegapi.cpp
+++ b/src/egegapi.cpp
@@ -34,6 +34,13 @@ void guiupdate(_graph_setting* pg, egeControlBase* &root);
 float _GetFPS(int add);
 int getflush();
 
+LPSTR w2mb(LPCWSTR wStr) {
+	int bufsize = WideCharToMultiByte(CP_ACP, 0, wStr, -1, NULL, 0, 0, 0);
+	CHAR* mbStr = new CHAR[bufsize];
+	WideCharToMultiByte(CP_ACP, 0, wStr, -1, mbStr, bufsize, 0, 0);
+	return mbStr;
+}
+
 double
 get_highfeq_time_ls(struct _graph_setting * pg) {
 	static LARGE_INTEGER llFeq = {{0}}; /* 此实为常数 */

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -667,8 +667,8 @@ init_instance(HINSTANCE hInstance, int nCmdShow) {
 	if (pg->is_unicode) {
 		pg->hwnd = CreateWindowExW(
 			g_windowexstyle,
-			pg->window_class_name,
-			pg->window_caption,
+			pg->window_class_name.c_str(),
+			pg->window_caption.c_str(),
 			g_windowstyle & ~WS_VISIBLE,
 			g_windowpos_x,
 			g_windowpos_y,
@@ -680,8 +680,8 @@ init_instance(HINSTANCE hInstance, int nCmdShow) {
 			NULL
 			);
 	} else {
-		const std::string& wndClsName = w2mb(pg->window_class_name);
-		const std::string& wndCaption = w2mb(pg->window_caption);
+		const std::string& wndClsName = w2mb(pg->window_class_name.c_str());
+		const std::string& wndCaption = w2mb(pg->window_caption.c_str());
 		
 		pg->hwnd = CreateWindowExA(
 			g_windowexstyle,
@@ -1134,7 +1134,7 @@ static
 ATOM
 register_classA(struct _graph_setting * pg, HINSTANCE hInstance) {
 	WNDCLASSEXA wcex ={0};
-	const std::string& wndClsName = w2mb(pg->window_class_name);
+	const std::string& wndClsName = w2mb(pg->window_class_name.c_str());
 	
 	wcex.cbSize = sizeof(wcex);
 
@@ -1166,7 +1166,7 @@ register_classW(struct _graph_setting * pg, HINSTANCE hInstance) {
 	wcex.hIcon          = pg->window_hicon;
 	wcex.hCursor        = LoadCursor(NULL, IDC_ARROW);
 	wcex.hbrBackground  = (HBRUSH)(COLOR_WINDOW+1);
-	wcex.lpszClassName  = pg->window_class_name;
+	wcex.lpszClassName  = pg->window_class_name.c_str();
 
 	return RegisterClassExW(&wcex);
 }
@@ -1319,7 +1319,7 @@ initgraph(int *gdriver, int *gmode, char *path) {
 	pg->window_class_name = L"Easy Graphics Engine";
 
 	// 若未调用 setcaption，设置默认标题
-	if (pg->window_caption == NULL) {
+	if (pg->window_caption.empty()) {
 		setcaption(EGE_TITLE);
 	}
 

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -106,7 +106,8 @@
 
 namespace ege {
 
-struct _graph_setting& graph_setting = *(struct _graph_setting*)calloc(1, sizeof(struct _graph_setting));
+// 静态分配，零初始化
+struct _graph_setting graph_setting;
 
 static DWORD    g_windowstyle = WS_OVERLAPPED|WS_CAPTION|WS_SYSMENU|WS_MINIMIZEBOX|WS_CLIPCHILDREN|WS_VISIBLE;
 static DWORD    g_windowexstyle = WS_EX_LEFT|WS_EX_LTRREADING;
@@ -679,13 +680,13 @@ init_instance(HINSTANCE hInstance, int nCmdShow) {
 			NULL
 			);
 	} else {
-		CHAR* wndClsName = w2mb(pg->window_class_name);
-		CHAR* wndCaption = w2mb(pg->window_caption);
+		const std::string& wndClsName = w2mb(pg->window_class_name);
+		const std::string& wndCaption = w2mb(pg->window_caption);
 		
 		pg->hwnd = CreateWindowExA(
 			g_windowexstyle,
-			wndClsName,
-			wndCaption,
+			wndClsName.c_str(),
+			wndCaption.c_str(),
 			g_windowstyle & ~WS_VISIBLE,
 			g_windowpos_x,
 			g_windowpos_y,
@@ -696,8 +697,6 @@ init_instance(HINSTANCE hInstance, int nCmdShow) {
 			hInstance,
 			NULL
 			);
-		delete[] wndClsName;
-		delete[] wndCaption;
 	}
 
 	if (!pg->hwnd) {
@@ -1135,7 +1134,7 @@ static
 ATOM
 register_classA(struct _graph_setting * pg, HINSTANCE hInstance) {
 	WNDCLASSEXA wcex ={0};
-	CHAR* wndClsName = w2mb(pg->window_class_name);
+	const std::string& wndClsName = w2mb(pg->window_class_name);
 	
 	wcex.cbSize = sizeof(wcex);
 
@@ -1147,12 +1146,9 @@ register_classA(struct _graph_setting * pg, HINSTANCE hInstance) {
 	wcex.hIcon          = pg->window_hicon;
 	wcex.hCursor        = LoadCursor(NULL, IDC_ARROW);
 	wcex.hbrBackground  = (HBRUSH)(COLOR_WINDOW+1);
-	wcex.lpszClassName  = wndClsName;
+	wcex.lpszClassName  = wndClsName.c_str();
 
-	ATOM atom = RegisterClassExA(&wcex);
-
-	delete[] wndClsName;
-	return atom;
+	return RegisterClassExA(&wcex);
 }
 
 static
@@ -1316,7 +1312,6 @@ initgraph(int *gdriver, int *gmode, char *path) {
 	}
 
 	//初始化环境
-	//memset(pg, 0, sizeof(_graph_setting)); // no need
 	setmode(*gdriver, *gmode);	
 	init_img_page(pg);
 


### PR DESCRIPTION
- 增加函数 `ege::seticon`，支持通过传入图标资源 ID 设置 EGE 窗口图标。
- 允许在 `ege::initgraph` 之前调用 `ege::setcaption` 或 `ege::seticon`
- 增加初始化选项 `INIT_UNICODE`，可由使用者选择创建 Unicode 窗口
- 将一些函数调用由宏改为显式调用 ANSI/UNICODE 版本