### PR TITLE
重构 global_settings 一些变量

### DIFF
--- a/src/ege_head.h
+++ b/src/ege_head.h
@@ -16,11 +16,11 @@
 #endif
 
 
-#define TOSTRING_(x)  #x
-#define TOSTRING(x)   TOSTRING_(x)
+#define EGE_TOSTR_(x)  #x
+#define EGE_TOSTR(x)   EGE_TOSTR_(x)
 
-#define L__(str)       L##str
-#define L_(str)        L__(str)
+#define EGE_L_(str)    L##str
+#define EGE_L(str)     EGE_L_(str)
 
 //编译器版本，目前仅支持 MSVC/MinGW
 #ifdef _WIN64
@@ -29,7 +29,7 @@
 #	define SYSBITS "x86"
 #endif
 
-#define SYSBITS_W  L_(SYSBITS)
+#define SYSBITS_W  EGE_L(SYSBITS)
 
 #ifdef _MSC_VER
 #	if (_MSC_VER >= 1930)
@@ -54,10 +54,10 @@
 #		define MSVC_VER "VC6"
 #	endif
 #	define COMPILER_VER     MSVC_VER SYSBITS
-#	define COMPILER_VER_W   L_(MSVC_VER) SYSBITS_W
+#	define COMPILER_VER_W   EGE_L(MSVC_VER) SYSBITS_W
 #else
-#	define GCC_VER          TOSTRING(__GNUC__) "." TOSTRING(__GNUC_MINOR__)
-#	define GCC_VER_W        L_(TOSTRING(__GNUC__)) L"." L_(TOSTRING(__GNUC_MINOR__))
+#	define GCC_VER          EGE_TOSTR(__GNUC__) "." EGE_TOSTR(__GNUC_MINOR__)
+#	define GCC_VER_W        EGE_L(EGE_TOSTR(__GNUC__)) L"." EGE_L(EGE_TOSTR(__GNUC_MINOR__))
 #	define COMPILER_VER     "GCC"   GCC_VER    SYSBITS
 #	define COMPILER_VER_W   L"GCC"  GCC_VER_W  SYSBITS_W
 #endif
@@ -66,13 +66,13 @@
 #define EGE_VERSION_MONTH 05
 
 #define EGE_VERSION_INT EGE_VERSION_YEAR * 100 + EGE_VERSION_MONTH
-#define EGE_VERSION     TOSTRING(EGE_VERSION_YEAR)     "."  TOSTRING(EGE_VERSION_MONTH)
-#define EGE_VERSION_W   L_(TOSTRING(EGE_VERSION_YEAR)) L"." L_(TOSTRING(EGE_VERSION_MONTH))
+#define EGE_VERSION     EGE_TOSTR(EGE_VERSION_YEAR) "." EGE_TOSTR(EGE_VERSION_MONTH)
+#define EGE_VERSION_W   EGE_L(EGE_TOSTR(EGE_VERSION_YEAR)) L"." EGE_L(EGE_TOSTR(EGE_VERSION_MONTH))
 #define EGE_TITLE       "EGE"  EGE_VERSION   " "  COMPILER_VER
 #define EGE_TITLE_W     L"EGE" EGE_VERSION_W L" " COMPILER_VER_W
 
 #define EGE_WNDCLSNAME    "Easy Graphics Engine"
-#define EGE_WNDCLSNAME_W  L_(EGE_WNDCLSNAME)
+#define EGE_WNDCLSNAME_W  EGE_L(EGE_WNDCLSNAME)
 
 // MSVC 从 10.0（VS2010）开始有 stdint.h
 // GCC 从 4.5 开始有 stdint.h

--- a/src/ege_head.h
+++ b/src/ege_head.h
@@ -16,53 +16,63 @@
 #endif
 
 
-#define TOSTRING_(x) #x
-#define TOSTRING(x) TOSTRING_(x)
+#define TOSTRING_(x)  #x
+#define TOSTRING(x)   TOSTRING_(x)
 
-#define CONCAT_(a, b) a##b
-#define CONCAT(a, b) CONCAT_(a, b)
+#define L__(str)       L##str
+#define L_(str)        L__(str)
 
 //编译器版本，目前仅支持 MSVC/MinGW
 #ifdef _WIN64
-#	define SYSBITS TEXT("x64")
+#	define SYSBITS "x64"
 #else
-#	define SYSBITS TEXT("x86")
+#	define SYSBITS "x86"
 #endif
 
+#define SYSBITS_W  L_(SYSBITS)
+
 #ifdef _MSC_VER
-#	if (_MSC_VER >= 2000)
-#		define COMPILER_VER TEXT("VC201x") SYSBITS
+#	if (_MSC_VER >= 1930)
+#		define MSVC_VER "MSVC"
+#	elif (_MSC_VER >= 1920)
+#		define MSVC_VER "VC2019"
 #	elif (_MSC_VER >= 1910)
-#		define COMPILER_VER TEXT("VC2017") SYSBITS
+#		define MSVC_VER "VC2017"
 #	elif (_MSC_VER >= 1900)
-#		define COMPILER_VER TEXT("VC2015") SYSBITS
+#		define MSVC_VER "VC2015"
 #	elif (_MSC_VER >= 1800)
-#		define COMPILER_VER TEXT("VC2013") SYSBITS
+#		define MSVC_VER "VC2013"
 #	elif (_MSC_VER >= 1700)
-#		define COMPILER_VER TEXT("VC2012") SYSBITS
+#		define MSVC_VER "VC2012"
 #	elif (_MSC_VER >= 1600)
-#		define COMPILER_VER TEXT("VC2010") SYSBITS
+#		define MSVC_VER "VC2010"
 #	elif (_MSC_VER >= 1500)
-#		define COMPILER_VER TEXT("VC2008") SYSBITS
+#		define MSVC_VER "VC2008"
 #	elif (_MSC_VER > 1200)
-#		define COMPILER_VER TEXT("VC2005") SYSBITS
+#		define MSVC_VER "VC2005"
 #	else
-#		define COMPILER_VER TEXT("VC6") SYSBITS
+#		define MSVC_VER "VC6"
 #	endif
+#	define COMPILER_VER     MSVC_VER SYSBITS
+#	define COMPILER_VER_W   L_(MSVC_VER) SYSBITS_W
 #else
-#	define GCC_VER TEXT(TOSTRING(__GNUC__)) TEXT(".") TEXT(TOSTRING(__GNUC_MINOR__))
-#	define COMPILER_VER TEXT("GCC") GCC_VER SYSBITS
+#	define GCC_VER          TOSTRING(__GNUC__) "." TOSTRING(__GNUC_MINOR__)
+#	define GCC_VER_W        L_(TOSTRING(__GNUC__)) L"." L_(TOSTRING(__GNUC_MINOR__))
+#	define COMPILER_VER     "GCC"   GCC_VER    SYSBITS
+#	define COMPILER_VER_W   L"GCC"  GCC_VER_W  SYSBITS_W
 #endif
 
 #define EGE_VERSION_YEAR  20
 #define EGE_VERSION_MONTH 05
 
 #define EGE_VERSION_INT EGE_VERSION_YEAR * 100 + EGE_VERSION_MONTH
-#define EGE_VERSION     TEXT(TOSTRING(EGE_VERSION_YEAR)) TEXT(".") TEXT(TOSTRING(EGE_VERSION_MONTH))
-#define EGE_TITLE       TEXT("EGE") EGE_VERSION TEXT(" ") COMPILER_VER
+#define EGE_VERSION     TOSTRING(EGE_VERSION_YEAR)     "."  TOSTRING(EGE_VERSION_MONTH)
+#define EGE_VERSION_W   L_(TOSTRING(EGE_VERSION_YEAR)) L"." L_(TOSTRING(EGE_VERSION_MONTH))
+#define EGE_TITLE       "EGE"  EGE_VERSION   " "  COMPILER_VER
+#define EGE_TITLE_W     L"EGE" EGE_VERSION_W L" " COMPILER_VER_W
 
 #define EGE_WNDCLSNAME    "Easy Graphics Engine"
-#define EGE_WNDCLSNAME_W  CONCAT(L, EGE_WNDCLSNAME)
+#define EGE_WNDCLSNAME_W  L_(EGE_WNDCLSNAME)
 
 // MSVC 从 10.0（VS2010）开始有 stdint.h
 // GCC 从 4.5 开始有 stdint.h
@@ -418,7 +428,6 @@ struct _graph_setting {
 
 	HINSTANCE instance;
 	HWND    hwnd;
-	std::wstring window_class_name;
 	std::wstring window_caption;
 	HICON   window_hicon;
 	int     exit_flag;
@@ -471,6 +480,10 @@ struct _graph_setting {
 
 	/* 函数用临时缓冲区 */
 	DWORD g_t_buff[1024 * 8];
+
+	_graph_setting() {
+		window_caption = EGE_TITLE_W;
+	}
 };
 
 extern struct _graph_setting graph_setting;

--- a/src/ege_head.h
+++ b/src/ege_head.h
@@ -15,6 +15,55 @@
 #define _ALLOW_RUNTIME_LIBRARY_MISMATCH
 #endif
 
+
+#define TOSTRING_(x) #x
+#define TOSTRING(x) TOSTRING_(x)
+
+#define CONCAT_(a, b) a##b
+#define CONCAT(a, b) CONCAT_(a, b)
+
+//编译器版本，目前仅支持 MSVC/MinGW
+#ifdef _WIN64
+#	define SYSBITS TEXT("x64")
+#else
+#	define SYSBITS TEXT("x86")
+#endif
+
+#ifdef _MSC_VER
+#	if (_MSC_VER >= 2000)
+#		define COMPILER_VER TEXT("VC201x") SYSBITS
+#	elif (_MSC_VER >= 1910)
+#		define COMPILER_VER TEXT("VC2017") SYSBITS
+#	elif (_MSC_VER >= 1900)
+#		define COMPILER_VER TEXT("VC2015") SYSBITS
+#	elif (_MSC_VER >= 1800)
+#		define COMPILER_VER TEXT("VC2013") SYSBITS
+#	elif (_MSC_VER >= 1700)
+#		define COMPILER_VER TEXT("VC2012") SYSBITS
+#	elif (_MSC_VER >= 1600)
+#		define COMPILER_VER TEXT("VC2010") SYSBITS
+#	elif (_MSC_VER >= 1500)
+#		define COMPILER_VER TEXT("VC2008") SYSBITS
+#	elif (_MSC_VER > 1200)
+#		define COMPILER_VER TEXT("VC2005") SYSBITS
+#	else
+#		define COMPILER_VER TEXT("VC6") SYSBITS
+#	endif
+#else
+#	define GCC_VER TEXT(TOSTRING(__GNUC__)) TEXT(".") TEXT(TOSTRING(__GNUC_MINOR__))
+#	define COMPILER_VER TEXT("GCC") GCC_VER SYSBITS
+#endif
+
+#define EGE_VERSION_YEAR  20
+#define EGE_VERSION_MONTH 05
+
+#define EGE_VERSION_INT EGE_VERSION_YEAR * 100 + EGE_VERSION_MONTH
+#define EGE_VERSION     TEXT(TOSTRING(EGE_VERSION_YEAR)) TEXT(".") TEXT(TOSTRING(EGE_VERSION_MONTH))
+#define EGE_TITLE       TEXT("EGE") EGE_VERSION TEXT(" ") COMPILER_VER
+
+#define EGE_WNDCLSNAME    "Easy Graphics Engine"
+#define EGE_WNDCLSNAME_W  CONCAT(L, EGE_WNDCLSNAME)
+
 // MSVC 从 10.0（VS2010）开始有 stdint.h
 // GCC 从 4.5 开始有 stdint.h
 #if _MSC_VER >= 1600 || __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 5)

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -15,47 +15,6 @@
 本文件定义平台密切相关的操作及接口
 */
 
-//编译器版本，目前仅支持vc6/vc2008/vc2010/vc2012/mingw
-#ifdef _WIN64
-#	define SYSBITS TEXT("x64")
-#else
-#	define SYSBITS TEXT("x86")
-#endif
-
-#define TOSTRING_(x) #x
-#define TOSTRING(x) TOSTRING_(x)
-
-#ifdef _MSC_VER
-#	if (_MSC_VER >= 2000)
-#		define COMPILER_VER TEXT("VC201x") SYSBITS
-#	elif (_MSC_VER >= 1910)
-#		define COMPILER_VER TEXT("VC2017") SYSBITS
-#	elif (_MSC_VER >= 1900)
-#		define COMPILER_VER TEXT("VC2015") SYSBITS
-#	elif (_MSC_VER >= 1800)
-#		define COMPILER_VER TEXT("VC2013") SYSBITS
-#	elif (_MSC_VER >= 1700)
-#		define COMPILER_VER TEXT("VC2012") SYSBITS
-#	elif (_MSC_VER >= 1600)
-#		define COMPILER_VER TEXT("VC2010") SYSBITS
-#	elif (_MSC_VER >= 1500)
-#		define COMPILER_VER TEXT("VC2008") SYSBITS
-#	elif (_MSC_VER > 1200)
-#		define COMPILER_VER TEXT("VC2005") SYSBITS
-#	else
-#		define COMPILER_VER TEXT("VC6") SYSBITS
-#	endif
-#else
-#	define GCC_VER TEXT(TOSTRING(__GNUC__)) TEXT(".") TEXT(TOSTRING(__GNUC_MINOR__))
-#	define COMPILER_VER TEXT("GCC") GCC_VER SYSBITS
-#endif
-
-#define EGE_VERSION_YEAR 20
-#define EGE_VERSION_MONTH 05
-
-#define EGE_VERSION_INT EGE_VERSION_YEAR * 100 + EGE_VERSION_MONTH
-#define EGE_VERSION TEXT(TOSTRING(EGE_VERSION_YEAR)) TEXT(".") TEXT(TOSTRING(EGE_VERSION_MONTH))
-#define EGE_TITLE TEXT("EGE") EGE_VERSION TEXT(" ") COMPILER_VER
 
 #ifndef _ALLOW_ITERATOR_DEBUG_LEVEL_MISMATCH
 #define _ALLOW_ITERATOR_DEBUG_LEVEL_MISMATCH
@@ -1316,7 +1275,7 @@ initgraph(int *gdriver, int *gmode, char *path) {
 	init_img_page(pg);
 
 	pg->instance = GetModuleHandle(NULL);
-	pg->window_class_name = L"Easy Graphics Engine";
+	pg->window_class_name = EGE_WNDCLSNAME_W;
 
 	// 若未调用 setcaption，设置默认标题
 	if (pg->window_caption.empty()) {

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -626,7 +626,7 @@ init_instance(HINSTANCE hInstance, int nCmdShow) {
 	if (pg->is_unicode) {
 		pg->hwnd = CreateWindowExW(
 			g_windowexstyle,
-			pg->window_class_name.c_str(),
+			EGE_WNDCLSNAME_W,
 			pg->window_caption.c_str(),
 			g_windowstyle & ~WS_VISIBLE,
 			g_windowpos_x,
@@ -639,12 +639,11 @@ init_instance(HINSTANCE hInstance, int nCmdShow) {
 			NULL
 			);
 	} else {
-		const std::string& wndClsName = w2mb(pg->window_class_name.c_str());
 		const std::string& wndCaption = w2mb(pg->window_caption.c_str());
 		
 		pg->hwnd = CreateWindowExA(
 			g_windowexstyle,
-			wndClsName.c_str(),
+			EGE_WNDCLSNAME,
 			wndCaption.c_str(),
 			g_windowstyle & ~WS_VISIBLE,
 			g_windowpos_x,
@@ -1093,7 +1092,6 @@ static
 ATOM
 register_classA(struct _graph_setting * pg, HINSTANCE hInstance) {
 	WNDCLASSEXA wcex ={0};
-	const std::string& wndClsName = w2mb(pg->window_class_name.c_str());
 	
 	wcex.cbSize = sizeof(wcex);
 
@@ -1105,7 +1103,7 @@ register_classA(struct _graph_setting * pg, HINSTANCE hInstance) {
 	wcex.hIcon          = pg->window_hicon;
 	wcex.hCursor        = LoadCursor(NULL, IDC_ARROW);
 	wcex.hbrBackground  = (HBRUSH)(COLOR_WINDOW+1);
-	wcex.lpszClassName  = wndClsName.c_str();
+	wcex.lpszClassName  = EGE_WNDCLSNAME;
 
 	return RegisterClassExA(&wcex);
 }
@@ -1125,7 +1123,7 @@ register_classW(struct _graph_setting * pg, HINSTANCE hInstance) {
 	wcex.hIcon          = pg->window_hicon;
 	wcex.hCursor        = LoadCursor(NULL, IDC_ARROW);
 	wcex.hbrBackground  = (HBRUSH)(COLOR_WINDOW+1);
-	wcex.lpszClassName  = pg->window_class_name.c_str();
+	wcex.lpszClassName  = EGE_WNDCLSNAME_W;
 
 	return RegisterClassExW(&wcex);
 }
@@ -1275,12 +1273,6 @@ initgraph(int *gdriver, int *gmode, char *path) {
 	init_img_page(pg);
 
 	pg->instance = GetModuleHandle(NULL);
-	pg->window_class_name = EGE_WNDCLSNAME_W;
-
-	// 若未调用 setcaption，设置默认标题
-	if (pg->window_caption.empty()) {
-		setcaption(EGE_TITLE);
-	}
 
 	initicon();
 


### PR DESCRIPTION
- 将版本宏定义移到 ege_head.h 中
- 去掉全局变量中的 `window_class_name`，以编译期常量代替
- 使用全局变量的默认构造函数自动初始化窗口标题