### PR TITLE
部分重构 IMAGE 类

### DIFF
--- a/demo/egedemo.cpp
+++ b/demo/egedemo.cpp
@@ -262,6 +262,7 @@ public:
 \n    }\
 \n    getch();\n    return 0;\n}";
             resize(img, 320, 480);
+            cleardevice(img);
             setfont(12, 0, "宋体", img);
             setbkmode(TRANSPARENT, img);
             setcolor(0x808080, img);
@@ -335,6 +336,7 @@ public:
 \n    }\
 \n    getch();\n    return 0;\n}";
             resize(img, 320, 480);
+            cleardevice(img);
             setfont(12, 0, "宋体", img);
             setbkmode(TRANSPARENT, img);
             setcolor(0x808080, img);
@@ -400,6 +402,7 @@ public:
 \n        }\
 \n    }\n    getch();\n    return 0;\n}";
             resize(img, 320, 480);
+            cleardevice(img);
             setfont(12, 0, "宋体", img);
             setbkmode(TRANSPARENT, img);
             setcolor(0x808080, img);
@@ -498,6 +501,7 @@ public:
 \n        setcolor(HSVtoRGB((float)color, 1.0f, 1.0f));\
 \n        circle(x, 100, 100);\n    }\n    getch();\n    return 0;\n}";
             resize(img, 320, 480);
+            cleardevice(img);
             setfont(12, 0, "宋体", img);
             setbkmode(TRANSPARENT, img);
             setcolor(0x808080, img);
@@ -587,6 +591,7 @@ public:
 \n        setcolor(0xFF0080);\
 \n        circle(x, 100, 100);\n    }\n    getch();\n    return 0;\n}";
             resize(img, 320, 480);
+            cleardevice(img);
             setfont(12, 0, "宋体", img);
             setbkmode(TRANSPARENT, img);
             setcolor(0x808080, img);
@@ -942,6 +947,7 @@ public:
 ";
             m_resettext = 0;
             resize(img, 320, 480);
+            cleardevice(img);
             setfont(12, 0, "宋体", img);
             setbkmode(TRANSPARENT, img);
             setcolor(0x808080, img);
@@ -1018,6 +1024,7 @@ public:
 \n    }\
 \n    getch();\n    return 0;\n}";
             resize(img, 320, 480);
+            cleardevice(img);
             setfont(12, 0, "宋体", img);
             setbkmode(TRANSPARENT, img);
             setcolor(0x808080, img);

--- a/src/ege.h
+++ b/src/ege.h
@@ -655,6 +655,7 @@ struct VECTOR3D {
 
 class IMAGE;
 typedef IMAGE *PIMAGE;
+typedef const IMAGE *PCIMAGE;
 
 // 绘图环境相关函数
 

--- a/src/ege_head.h
+++ b/src/ege_head.h
@@ -240,7 +240,8 @@ public:
 	color_t     m_fillcolor;
 	bool        m_aa;
 private:
-	int  newimage(HDC hdc, int width, int height);
+	void initimage(HDC refDC, int width, int height);
+	void setdefaultattribute();
 	int  deleteimage();
 	void reset();
 public:
@@ -257,7 +258,7 @@ private:
 public:
 	IMAGE();
 	IMAGE(int width, int height);
-	IMAGE(IMAGE &img);              // 拷贝构造函数
+	IMAGE(const IMAGE &img);              // 拷贝构造函数
 	IMAGE& operator = (const IMAGE &img); // 赋值运算符重载函数
 	~IMAGE();
 	void set_pattern(void* obj, int type);
@@ -269,11 +270,10 @@ public:
 	int getheight()    const {return m_height;}
 	color_t* getbuffer() const {return (color_t*)m_pBuffer;}
 
-	int  createimage(int width, int height);
 	int  resize(int width, int height);
-	void copyimage(const PIMAGE pSrcImg);
+	void copyimage(PCIMAGE pSrcImg);
 	void getimage(int srcX, int srcY, int srcWidth, int srcHeight);
-	void getimage(const PIMAGE pSrcImg, int srcX, int srcY, int srcWidth, int srcHeight);
+	void getimage(PCIMAGE pSrcImg, int srcX, int srcY, int srcWidth, int srcHeight);
 	int  getimage(LPCSTR pImgFile, int zoomWidth = 0, int zoomHeight = 0);
 	int  getimage(LPCWSTR pImgFile, int zoomWidth = 0, int zoomHeight = 0);
 	int  getimage(LPCSTR pResType, LPCSTR pResName, int zoomWidth = 0, int zoomHeight = 0);
@@ -551,6 +551,10 @@ private:
 
 // convert wide string to multibyte string
 std::string w2mb(LPCWSTR wStr);
+
+void internal_panic(LPCWSTR errmsg);
+
+HBITMAP newbitmap(int width, int height, PDWORD* p_bmp_buf);
 
 } // namespace ege
 

--- a/src/ege_head.h
+++ b/src/ege_head.h
@@ -436,7 +436,6 @@ struct _graph_setting {
 	bool    close_manually;
 	bool    use_force_exit; //强制关闭进程标记
 	bool    lock_window;
-	bool    init_finish;
 	bool    timer_stop_mark;
 	bool    skip_timer_mark;
 

--- a/src/ege_head.h
+++ b/src/ege_head.h
@@ -415,7 +415,6 @@ struct _graph_setting {
 	int writemode;
 
 	HDC dc;
-	HDC window_dc;
 	int dc_w, dc_h;
 	PIMAGE img_page[BITMAP_PAGE_SIZE];
 	int base_x, base_y, base_w, base_h;

--- a/src/ege_head.h
+++ b/src/ege_head.h
@@ -241,6 +241,7 @@ public:
 	bool        m_aa;
 private:
 	void initimage(HDC refDC, int width, int height);
+	void construct(int width, int height);
 	void setdefaultattribute();
 	int  deleteimage();
 	void reset();

--- a/src/egegapi.cpp
+++ b/src/egegapi.cpp
@@ -41,6 +41,11 @@ std::string w2mb(LPCWSTR wStr) {
 	return mbStr;
 }
 
+void internal_panic(LPCWSTR errmsg) {
+	MessageBoxW(graph_setting.hwnd, errmsg, L"EGE INTERNAL ERROR", MB_ICONSTOP);
+	ExitProcess((UINT)grError);
+}
+
 double
 get_highfeq_time_ls(struct _graph_setting * pg) {
 	static LARGE_INTEGER llFeq = {{0}}; /* 此实为常数 */
@@ -1777,8 +1782,7 @@ setactivepage(int page) {
 		pg->active_page = page;
 		
 		if (pg->img_page[page] == NULL) {
-			pg->img_page[page] = new IMAGE;
-			pg->img_page[page]->createimage(pg->dc_w, pg->dc_h);
+			pg->img_page[page] = new IMAGE(pg->dc_w, pg->dc_h);
 		}
 
 		pg->imgtarget = pg->img_page[page];
@@ -1792,8 +1796,7 @@ setvisualpage(int page) {
 	if (0 <= page && page < BITMAP_PAGE_SIZE) {
 		pg->visual_page = page;
 		if (pg->img_page[page] == NULL) {
-			pg->img_page[page] = new IMAGE;
-			pg->img_page[page]->createimage(pg->dc_w, pg->dc_h);
+			pg->img_page[page] = new IMAGE(pg->dc_w, pg->dc_h);
 		}
 		pg->update_mark_count = 0;
 	}
@@ -2439,7 +2442,7 @@ inputbox_getline(LPCWSTR title, LPCWSTR text, LPWSTR buf, int len) {
 	int ret = 0;
 
 	bg.getimage(0, 0, getwidth(), getheight());
-	window.createimage(w, h);
+	window.resize(w, h);
 	buf[0] = 0;
 
 	lock_window = pg->lock_window;

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -1123,8 +1123,6 @@ register_classW(struct _graph_setting * pg, HINSTANCE hInstance) {
 /* private function */
 int
 graph_init(_graph_setting * pg) {
-	HDC hDC = GetDC(pg->hwnd);
-	pg->dc = hDC;
 	pg->img_timer_update = newimage();
 	pg->msgkey_queue = new thread_queue<EGEMSG>;
 	pg->msgmouse_queue = new thread_queue<EGEMSG>;
@@ -1132,7 +1130,6 @@ graph_init(_graph_setting * pg) {
 	settarget(NULL);
 	setvisualpage(0);
 	window_setviewport(0, 0, pg->dc_w, pg->dc_h);
-	//ReleaseDC(pg->hwnd, hDC);
 	return 0;
 }
 

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -72,7 +72,7 @@ static DWORD    g_windowstyle = WS_OVERLAPPED|WS_CAPTION|WS_SYSMENU|WS_MINIMIZEB
 static DWORD    g_windowexstyle = WS_EX_LEFT|WS_EX_LTRREADING;
 static int      g_windowpos_x = CW_USEDEFAULT;
 static int      g_windowpos_y = CW_USEDEFAULT;
-static int      g_initoption  = INIT_DEFAULT, g_initcall = 0;
+static int      g_initoption  = INIT_DEFAULT;
 static HWND     g_attach_hwnd = 0;
 static WNDPROC  DefWindowProcFunc = NULL;
 
@@ -1287,14 +1287,12 @@ initgraph(int *gdriver, int *gmode, char *path) {
 
 	//SECURITY_ATTRIBUTES sa = {0};
 	DWORD pid;
-	pg->init_finish = false;
 	pg->threadui_handle = CreateThread(NULL, 0, messageloopthread, pg, CREATE_SUSPENDED, &pid);
 	ResumeThread(pg->threadui_handle);
 
-	while (!pg->init_finish) {
+	while (!pg->has_init) {
 		Sleep(1);
 	}
-	pg->has_init = true;
 
 	UpdateWindow(pg->hwnd);
 
@@ -1317,7 +1315,7 @@ void
 initgraph(int Width, int Height, int Flag) {
 	int g = TRUECOLORSIZE, m = (Width) | (Height<<16);
 
-	if (!g_initcall)
+	if (!graph_setting.has_init)
 		setinitmode(Flag);
 
 	initgraph(&g, &m, (char*)"");
@@ -1373,7 +1371,7 @@ messageloopthread(LPVOID lpParameter) {
 			SetTimer(pg->hwnd, RENDER_TIMER_ID, 50, NULL);
 		}
 	}
-	pg->init_finish = true;
+	pg->has_init = true;
 
 	if (pg->is_unicode) {
 		while (!pg->exit_window) {
@@ -1401,7 +1399,6 @@ messageloopthread(LPVOID lpParameter) {
 
 void
 setinitmode(int mode, int x, int y) {
-	g_initcall = 1;
 	g_initoption = mode;
 	struct _graph_setting * pg = &graph_setting;
 	if (mode & INIT_NOBORDER) {

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -147,14 +147,10 @@ graphupdate(_graph_setting* pg) {
 		return grNoInitGraph;
 	}
 	{
-		HDC hdc;
 		if( IsWindowVisible(pg->hwnd)) {
-			hdc = pg->window_dc;
-
-			if (hdc == NULL) {
-				return grNullPointer;
-			}
+			HDC hdc = ::GetDC(pg->hwnd);
 			redraw_window(pg, hdc);
+			::ReleaseDC(pg->hwnd, hdc);
 		} else {
 			pg->update_mark_count = UPDATE_MAX_CALL;
 		}
@@ -804,10 +800,6 @@ static
 void
 on_destroy(struct _graph_setting * pg) {
 	pg->exit_window = 1;
-	if (pg->dc) {
-		ReleaseDC(pg->hwnd, pg->window_dc);
-		// release objects, not finish
-	}
 	PostQuitMessage(0);
 	if (pg->close_manually && pg->use_force_exit) {
 		ExitProcess(0);
@@ -1133,7 +1125,6 @@ int
 graph_init(_graph_setting * pg) {
 	HDC hDC = GetDC(pg->hwnd);
 	pg->dc = hDC;
-	pg->window_dc = hDC;
 	pg->img_timer_update = newimage();
 	pg->msgkey_queue = new thread_queue<EGEMSG>;
 	pg->msgmouse_queue = new thread_queue<EGEMSG>;

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -69,6 +69,9 @@ IMAGE::IMAGE() {
 }
 
 IMAGE::IMAGE(int width, int height) {
+	// Ωÿ÷πµΩ 0
+	if (width < 0) width = 0;
+	if (height < 0) height = 0;
 	construct(width, height);
 }
 
@@ -155,9 +158,13 @@ HBITMAP newbitmap(int width, int height, PDWORD* p_bmp_buf) {
 	BITMAPINFO bmi = {{0}};
 	PDWORD bmp_buf;
 
+	// Ωÿ÷πµΩ 1
+	if (width < 1) width = 1;
+	if (height < 1) height = 1;
+
 	bmi.bmiHeader.biSize = sizeof(bmi.bmiHeader);
 	bmi.bmiHeader.biWidth = width;
-	bmi.bmiHeader.biHeight = -height - 1;
+	bmi.bmiHeader.biHeight = -height;
 	bmi.bmiHeader.biPlanes = 1;
 	bmi.bmiHeader.biBitCount = 32;
 	bmi.bmiHeader.biSizeImage = width * height * 4;
@@ -214,6 +221,11 @@ void IMAGE::setdefaultattribute() {
 int
 IMAGE::resize(int width, int height) {
 	inittest(L"IMAGE::resize");
+
+	// Ωÿ÷πµΩ 0
+	if (width < 0) width = 0;
+	if (height < 0) height = 0;
+
 	PDWORD bmp_buf;
 	HBITMAP bitmap     = newbitmap(width, height, &bmp_buf);
 	HBITMAP old_bitmap = (HBITMAP)SelectObject(this->m_hDC, bitmap);

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -204,7 +204,6 @@ void IMAGE::initimage(HDC refDC, int width, int height) {
 	m_pBuffer = bmp_buf;
 
 	setviewport(0, 0, m_width, m_height, 1, this);
-	cleardevice(this);
 }
 
 void IMAGE::setdefaultattribute() {
@@ -237,7 +236,6 @@ IMAGE::resize(int width, int height) {
 	m_pBuffer = bmp_buf;
 
 	setviewport(0, 0, m_width, m_height, 1, this);
-	cleardevice(this);
 
 	return 0;
 }

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -28,11 +28,6 @@
 
 namespace ege {
 
-static HBITMAP  g_hbmp_def;
-static HBRUSH   g_hbr_def;
-static HPEN     g_pen_def;
-static HFONT    g_font_def;
-
 void IMAGE::reset() {
 	m_initflag = IMAGE_INIT_FLAG;
 	m_hDC = NULL;
@@ -136,12 +131,19 @@ IMAGE::gentexture(bool gen) {
 
 int
 IMAGE::deleteimage() {
-	DeleteObject(SelectObject(m_hDC, g_hbmp_def));
-	DeleteObject(SelectObject(m_hDC, g_hbr_def));
-	DeleteObject(SelectObject(m_hDC, g_pen_def));
-	DeleteObject(SelectObject(m_hDC, g_font_def));
+	HBITMAP hbmp  = (HBITMAP)GetCurrentObject(m_hDC, OBJ_BITMAP);
+	HBRUSH  hbr   = (HBRUSH)GetCurrentObject(m_hDC, OBJ_BRUSH);
+	HPEN    hpen  = (HPEN)GetCurrentObject(m_hDC, OBJ_PEN);
+	HFONT   hfont = (HFONT)GetCurrentObject(m_hDC, OBJ_FONT);
+
 	DeleteDC(m_hDC);
 	m_hDC = NULL;
+
+	DeleteObject(hbmp);
+	DeleteObject(hbr);
+	DeleteObject(hpen);
+	DeleteObject(hfont);
+	
 	return 0;
 }
 
@@ -188,12 +190,6 @@ IMAGE::newimage(HDC hdc, int width, int height) {
 		if (bitmap != NULL) {
 			HBITMAP hbmp_def = (HBITMAP)SelectObject(dc, bitmap);
 			int b_resize = 0;
-			if (g_hbmp_def == NULL) {
-				g_hbmp_def = hbmp_def;
-				g_hbr_def  = (HBRUSH)GetCurrentObject(dc, OBJ_BRUSH);
-				g_pen_def  = (HPEN)GetCurrentObject(dc, OBJ_PEN);
-				g_font_def = (HFONT)GetCurrentObject(dc, OBJ_FONT);
-			}
 			if (m_hDC) {
 				DeleteObject(hbmp_def);
 				b_resize = 1;

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -48,23 +48,7 @@ void IMAGE::reset() {
 	m_texture = NULL;
 }
 
-IMAGE::IMAGE() {
-	HDC refDC = NULL;
-
-	if (graph_setting.hwnd) {
-		refDC = ::GetDC(graph_setting.hwnd);
-	}
-
-	reset();
-	initimage(refDC, 1, 1);
-	setdefaultattribute();
-
-	if (refDC) {
-		::ReleaseDC(graph_setting.hwnd, refDC);
-	}
-}
-
-IMAGE::IMAGE(int width, int height) {
+void IMAGE::construct(int width, int height) {
 	HDC refDC = NULL;
 
 	if (graph_setting.hwnd) {
@@ -78,6 +62,14 @@ IMAGE::IMAGE(int width, int height) {
 	if (refDC) {
 		::ReleaseDC(graph_setting.hwnd, refDC);
 	}
+}
+
+IMAGE::IMAGE() {
+	construct(1, 1);
+}
+
+IMAGE::IMAGE(int width, int height) {
+	construct(width, height);
 }
 
 IMAGE::IMAGE(const IMAGE &img) {
@@ -203,12 +195,6 @@ void IMAGE::initimage(HDC refDC, int width, int height) {
 	m_width   = width;
 	m_height  = height;
 	m_pBuffer = bmp_buf;
-
-	m_vpt.left   = 0;
-	m_vpt.top    = 0;
-	m_vpt.right  = width;
-	m_vpt.bottom = height;
-	m_vpt.clipflag   = 1;
 
 	setviewport(0, 0, m_width, m_height, 1, this);
 	cleardevice(this);


### PR DESCRIPTION
把 `IMAGE::newimage` 一坨代码重构了。`IMAGE` 就是管理内存设备上下文（DC）的类，可以直接通过 `GetDC(NULL)` 得到屏幕 DC，然后用它建立内存 DC，因此不用先调用 `initgraph` 建立窗口。

关键 commit 是 04c1ae1。

无长宽参数时默认建立 1×1 大小的 `IMAGE` 对象保持不变，但允许建立长或宽为 0 的 `IMAGE` 对象以及将 `IMAGE` 对象的长或宽 `resize` 到 0 大小。