### PR TITLE
修正颜色格式相关

### DIFF
--- a/src/ege.h
+++ b/src/ege.h
@@ -161,18 +161,18 @@
 
 #define SHOWCONSOLE             1       // 进入图形模式时，保留控制台的显示
 #define RGBTOBGR(color)         ((((color) & 0xFF) << 16) | (((color) & 0xFF0000) >> 16) | ((color) & 0xFF00FF00))
-#define EGERGB(r, g, b)         ( ((r)<<16) | ((g)<<8) | (b))
 #define EGERGBA(r, g, b, a)     ( ((r)<<16) | ((g)<<8) | (b) | ((a)<<24) )
-#define EGEARGB(a, r, g, b)     ( ((r)<<16) | ((g)<<8) | (b) | ((a)<<24) )
+#define EGERGB(r, g, b)         EGERGBA(r, g, b, 0xFF)
+#define EGEARGB(a, r, g, b)     EGERGBA(r, g, b, a)
 #define EGEACOLOR(a, color)     ( ((color) & 0xFFFFFF) | ((a)<<24) )
-#define EGECOLORA(color, a)     ( ((color) & 0xFFFFFF) | ((a)<<24) )
+#define EGECOLORA(color, a)     EGEACOLOR(a, color)
 #define EGEGET_R(c)             ( ((c)>>16) & 0xFF )
 #define EGEGET_G(c)             ( ((c)>> 8) & 0xFF )
 #define EGEGET_B(c)             ( ((c)) & 0xFF )
 #define EGEGET_A(c)             ( ((c)>>24) & 0xFF )
-#define EGEGRAY(gray)           ( ((gray)<<16) | ((gray)<<8) | (gray))
-#define EGEGRAYA(gray, a)       ( ((gray)<<16) | ((gray)<<8) | (gray) | ((a)<<24) )
-#define EGEAGRAY(a, gray)       ( ((gray)<<16) | ((gray)<<8) | (gray) | ((a)<<24) )
+#define EGEGRAY(gray)           EGERGB(gray, gray, gray)
+#define EGEGRAYA(gray, a)       EGERGBA(gray, gray, gray, a)
+#define EGEAGRAY(a, gray)       EGEGRAYA(gray, a)
 #define NAMESPACE_EGE_L         namespace ege {
 #define NAMESPACE_EGE_R         }
 
@@ -263,7 +263,7 @@ enum message_mouse {
 
 // 颜色
 enum COLORS {
-	BLACK           = 0,
+	BLACK           = EGERGB(0, 0, 0),
 	BLUE            = EGERGB(0, 0, 0xA8),
 	GREEN           = EGERGB(0, 0xA8, 0),
 	CYAN            = EGERGB(0, 0xA8, 0xA8),

--- a/src/ege.h
+++ b/src/ege.h
@@ -160,7 +160,6 @@
 #endif
 
 #define SHOWCONSOLE             1       // 进入图形模式时，保留控制台的显示
-#define RGBTOBGR(color)         ((((color) & 0xFF) << 16) | (((color) & 0xFF0000) >> 16) | ((color) & 0xFF00FF00))
 #define EGERGBA(r, g, b, a)     ( ((r)<<16) | ((g)<<8) | (b) | ((a)<<24) )
 #define EGERGB(r, g, b)         EGERGBA(r, g, b, 0xFF)
 #define EGEARGB(a, r, g, b)     EGERGBA(r, g, b, a)

--- a/src/ege/sys_edit.h
+++ b/src/ege/sys_edit.h
@@ -79,25 +79,7 @@ public:
         }
         return 0;
     }
-    LRESULT onMessage(UINT message, WPARAM wParam, LPARAM lParam) {
-        if (message == WM_CTLCOLOREDIT) {
-            HDC dc = (HDC)wParam;
-            HBRUSH br = ::CreateSolidBrush(RGBTOBGR(m_bgcolor));
-
-            ::SetBkColor(dc, RGBTOBGR(m_bgcolor));
-            ::SetTextColor(dc, RGBTOBGR(m_color));
-            ::DeleteObject(m_hBrush);
-            m_hBrush = br;
-            return (LRESULT)br;
-        //} else if (message == WM_SETFOCUS) {
-        //    int a = 0;
-        //    int b = 1;
-        //    return 0;
-        } else {
-            return ((LRESULT (CALLBACK *)(HWND, UINT, WPARAM, LPARAM))m_callback)(m_hwnd, message, wParam, lParam);
-        }
-        //return 0;
-    }
+    LRESULT onMessage(UINT message, WPARAM wParam, LPARAM lParam);
     void visible(bool bvisible) {
         egeControlBase::visible(bvisible);
         ::ShowWindow(m_hwnd, (int)bvisible);

--- a/src/ege_head.h
+++ b/src/ege_head.h
@@ -132,6 +132,11 @@
 #define IFATODOB(A, B)  ( (A) && (B, 0) )
 #define IFNATODOB(A, B) ( (A) || (B, 0) )
 
+// 将 color_t 与 Bitmap Buffer 所用的 0xaarrggbb 格式
+// 转换为 COLORREF 所用的 0x00bbggrr，忽略 Alpha 通道
+// 仅用于向 GDI32 API 传递颜色时
+#define ARGBTOZBGR(c)   ((((c) & 0xFF) << 16) | (((c) & 0xFF0000) >> 16) | ((c) & 0xFF00))
+
 #define CONVERT_IMAGE(pimg) ( ((size_t)(pimg)<0x20 ?\
 		((pimg) ?\
 			(graph_setting.img_page[(size_t)(pimg) & 0xF])\

--- a/src/ege_head.h
+++ b/src/ege_head.h
@@ -132,6 +132,9 @@
 #define IFATODOB(A, B)  ( (A) && (B, 0) )
 #define IFNATODOB(A, B) ( (A) || (B, 0) )
 
+// 0xaarrggbb -> 0xaabbggrr
+#define RGBTOBGR(color)         ((((color) & 0xFF) << 16) | (((color) & 0xFF0000) >> 16) | ((color) & 0xFF00FF00))
+
 // 将 color_t 与 Bitmap Buffer 所用的 0xaarrggbb 格式
 // 转换为 COLORREF 所用的 0x00bbggrr，忽略 Alpha 通道
 // 仅用于向 GDI32 API 传递颜色时

--- a/src/egegapi.cpp
+++ b/src/egegapi.cpp
@@ -696,7 +696,7 @@ static int upattern2array(unsigned short upattern, DWORD style[]) {
 
 static void update_pen(PIMAGE img) {
 	LOGBRUSH lbr;
-	lbr.lbColor = RGBTOBGR(img->m_color) & 0x00FFFFFF;
+	lbr.lbColor = ARGBTOZBGR(img->m_color);
 	lbr.lbStyle = BS_SOLID;
 	lbr.lbHatch = 0;
 
@@ -728,7 +728,7 @@ setcolor(color_t color, PIMAGE pimg) {
 		img->m_color = color;
 
 		update_pen(img);
-		SetTextColor(img->m_hDC, RGBTOBGR(color) & 0x00FFFFFF);
+		SetTextColor(img->m_hDC, ARGBTOZBGR(color));
 	}
 	CONVERT_IMAGE_END;
 }
@@ -738,8 +738,7 @@ setfillcolor(color_t color, PIMAGE pimg) {
 	PIMAGE img = CONVERT_IMAGE_CONST(pimg);
 	LOGBRUSH lbr = {0};
 	img->m_fillcolor = color;
-	color = RGBTOBGR(color);
-	lbr.lbColor = color;
+	lbr.lbColor = ARGBTOZBGR(color);
 	lbr.lbHatch = BS_SOLID;
 	HBRUSH hbr = CreateBrushIndirect(&lbr);
 	if (hbr) {
@@ -780,7 +779,7 @@ setbkcolor(color_t color, PIMAGE pimg) {
 		int size = img->m_width * img->m_height;
 		color_t col = img->m_bk_color;
 		img->m_bk_color = color;
-		SetBkColor(img->m_hDC, RGBTOBGR(color));
+		SetBkColor(img->m_hDC, ARGBTOZBGR(color));
 		for (int n = 0; n < size; n++, p++) {
 			if (*p == col) {
 				*p = color;
@@ -795,7 +794,7 @@ setbkcolor_f(color_t color, PIMAGE pimg) {
 
 	if (img && img->m_hDC) {
 		img->m_bk_color = color;
-		SetBkColor(img->m_hDC, RGBTOBGR(color));
+		SetBkColor(img->m_hDC, ARGBTOZBGR(color));
 	}
 	CONVERT_IMAGE_END;
 }
@@ -804,7 +803,7 @@ void setfontbkcolor(color_t color, PIMAGE pimg) {
 	PIMAGE img = CONVERT_IMAGE(pimg);
 
 	if (img && img->m_hDC) {
-		SetBkColor(img->m_hDC, RGBTOBGR(color));
+		SetBkColor(img->m_hDC, ARGBTOZBGR(color));
 	}
 	CONVERT_IMAGE_END;
 }
@@ -1090,7 +1089,7 @@ void
 floodfill(int x, int y, int border, PIMAGE pimg) {
 	PIMAGE img = CONVERT_IMAGE(pimg);
 	if (img) {
-		FloodFill(img->m_hDC, x, y, RGBTOBGR(border));
+		FloodFill(img->m_hDC, x, y, ARGBTOZBGR(border));
 	}
 	CONVERT_IMAGE_END;
 }
@@ -1099,7 +1098,7 @@ void
 floodfillsurface(int x, int y, color_t areacolor, PIMAGE pimg) {
 	PIMAGE img = CONVERT_IMAGE(pimg);
 	if (img) {
-		ExtFloodFill(img->m_hDC, x, y, RGBTOBGR(areacolor), FLOODFILLSURFACE);
+		ExtFloodFill(img->m_hDC, x, y, ARGBTOZBGR(areacolor), FLOODFILLSURFACE);
 	}
 	CONVERT_IMAGE_END;
 }
@@ -1472,7 +1471,7 @@ setfillstyle(int pattern, color_t color, PIMAGE pimg) {
 	PIMAGE img = CONVERT_IMAGE_CONST(pimg);
 	LOGBRUSH lbr = {0};
 	img->m_fillcolor = color;
-	lbr.lbColor = RGBTOBGR(color);
+	lbr.lbColor = ARGBTOZBGR(color);
 	//SetBkColor(img->m_hDC, color);
 	if (pattern < SOLID_FILL) {
 		lbr.lbHatch = BS_NULL;

--- a/src/egegapi.cpp
+++ b/src/egegapi.cpp
@@ -2610,4 +2610,24 @@ ege_uncompress(void *dest, unsigned long *destLen, const void *source, unsigned 
 	}
 }
 
+LRESULT sys_edit::onMessage(UINT message, WPARAM wParam, LPARAM lParam) {
+	if (message == WM_CTLCOLOREDIT) {
+		HDC dc = (HDC)wParam;
+		HBRUSH br = ::CreateSolidBrush(ARGBTOZBGR(m_bgcolor));
+
+		::SetBkColor(dc, ARGBTOZBGR(m_bgcolor));
+		::SetTextColor(dc, ARGBTOZBGR(m_color));
+		::DeleteObject(m_hBrush);
+		m_hBrush = br;
+		return (LRESULT)br;
+	//} else if (message == WM_SETFOCUS) {
+	//    int a = 0;
+	//    int b = 1;
+	//    return 0;
+	} else {
+		return ((LRESULT (CALLBACK *)(HWND, UINT, WPARAM, LPARAM))m_callback)(m_hwnd, message, wParam, lParam);
+	}
+	//return 0;
+}
+
 } // namespace ege


### PR DESCRIPTION
设置预定义颜色与 `EGERGB` 宏产生的颜色的 Alpha 通道值为 255。
所有传入 GDI32 函数的颜色，都转换为 `COLERREF` 格式（0x00BBGGRR）。
从 ege.h 中移除了 `RGBTOBGR`。