### PR TITLE
修正初始化标志位设定的行为

### DIFF
--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -72,7 +72,7 @@ static DWORD    g_windowstyle = WS_OVERLAPPED|WS_CAPTION|WS_SYSMENU|WS_MINIMIZEB
 static DWORD    g_windowexstyle = WS_EX_LEFT|WS_EX_LTRREADING;
 static int      g_windowpos_x = CW_USEDEFAULT;
 static int      g_windowpos_y = CW_USEDEFAULT;
-static int      g_initoption  = INIT_DEFAULT;
+static int      g_initoption  = -1;
 static HWND     g_attach_hwnd = 0;
 static WNDPROC  DefWindowProcFunc = NULL;
 
@@ -1257,6 +1257,8 @@ initgraph(int *gdriver, int *gmode, char *path) {
 	}
 
 	//初始化环境
+	if (g_initoption == -1)
+		setinitmode();
 	setmode(*gdriver, *gmode);	
 	init_img_page(pg);
 
@@ -1303,7 +1305,7 @@ void
 initgraph(int Width, int Height, int Flag) {
 	int g = TRUECOLORSIZE, m = (Width) | (Height<<16);
 
-	if (!graph_setting.has_init)
+	if (g_initoption == -1)
 		setinitmode(Flag);
 
 	initgraph(&g, &m, (char*)"");


### PR DESCRIPTION
在 `initgraph` 前调用 `setinitmode`，以 `setinitmode` 为准