### PR TITLE
修改 `initgraph` 的定义，使代码更清晰

### DIFF
--- a/src/ege.h
+++ b/src/ege.h
@@ -577,12 +577,6 @@ struct msg_createwindow {
 };
 
 
-// 绘图环境初始化参数
-#define INITGRAPH(x, y) struct _initgraph_{_initgraph_(){initgraph(x, y);}\
-	~_initgraph_(){closegraph();}}_g_initgraph_
-#define INITGRAPH3(x, y, f) struct _initgraph_{_initgraph_(){initgraph(x, y, f);}\
-	~_initgraph_(){closegraph();}}_g_initgraph_
-
 //音乐类宏
 #define MUSIC_ERROR  0xFFFFFFFF
 

--- a/src/ege.h
+++ b/src/ege.h
@@ -339,6 +339,7 @@ enum music_state_flag {
 };
 
 enum initmode_flag {
+	INIT_DEFAULT        = 0x0,
 	INIT_NOBORDER       = 0x1,
 	INIT_CHILD          = 0x2,
 	INIT_TOPMOST        = 0x4,
@@ -346,12 +347,7 @@ enum initmode_flag {
 	INIT_NOFORCEEXIT    = 0x10,
 	INIT_UNICODE        = 0x20,
 	INIT_WITHLOGO       = 0x100,
-#if defined(_DEBUG) || defined(DEBUG)
-	INIT_DEFAULT    = 0x0,
-#else
-	INIT_DEFAULT    = INIT_WITHLOGO,
-#endif
-	INIT_ANIMATION  = INIT_DEFAULT | INIT_RENDERMANUAL | INIT_NOFORCEEXIT,
+	INIT_ANIMATION      = INIT_DEFAULT | INIT_RENDERMANUAL | INIT_NOFORCEEXIT,
 };
 
 enum rendermode_e {
@@ -657,14 +653,26 @@ typedef IMAGE *PIMAGE;
 typedef const IMAGE *PCIMAGE;
 
 // ªÊÕºª∑æ≥œ‡πÿ∫Ø ˝
-
-void EGEAPI initgraph(int Width, int Height, int Flag = INIT_DEFAULT);    // ≥ı ºªØÕº–Œª∑æ≥
-void EGEAPI initgraph(int* gdriver, int* gmode, char* path);   // ºÊ»› Borland C++ 3.1 µƒ÷ÿ‘ÿ£¨÷ª π”√ 640x480x24bit
-void EGEAPI closegraph();                                      // πÿ±’Õº–Œª∑æ≥
-bool EGEAPI is_run();   // ≈–∂œUI «∑ÒÕÀ≥ˆ
+void EGEAPI setinitmode(int mode, int x = CW_USEDEFAULT, int y = CW_USEDEFAULT); //…Ë÷√≥ı ºªØƒ£ Ω£¨mode=0Œ™∆’Õ®£¨1Œ™Œﬁ±ﬂøÚ¥∞ø⁄£¨xy «≥ı º¥∞ø⁄◊¯±Í
+int  EGEAPI getinitmode();
+void EGEAPI initgraph(int Width, int Height, int Flag);        // ≥ı ºªØÕº–Œª∑æ≥
+// Debug ≈‰÷√œ¬ƒ¨»œ≤ªœ‘ æ LOGO£¨Release ƒ£ Ωœ¬ƒ¨»œœ‘ æ°£
+#if !defined(NDEBUG) || defined(DEBUG) || defined(_DEBUG)
+inline void EGEAPI initgraph(int Width, int Height) {
+	initgraph(Width, Height, getinitmode());
+}
+#else
+inline void EGEAPI initgraph(int Width, int Height) {
+	initgraph(Width, Height, getinitmode()|INIT_WITHLOGO);
+}
+#endif
+void EGEAPI initgraph(int* gdriver, int* gmode, const char* path);  // ºÊ»› Borland C++ 3.1 µƒ÷ÿ‘ÿ£¨÷ª π”√ 640x480x24bit
+void EGEAPI closegraph();                                           // πÿ±’Õº–Œª∑æ≥
+bool EGEAPI is_run();                                               // ≈–∂œUI «∑ÒÕÀ≥ˆ
 void EGEAPI setcaption(LPCSTR  caption);
 void EGEAPI setcaption(LPCWSTR caption);
 void EGEAPI seticon(int icon_id);
+int  EGEAPI attachHWND(HWND hWnd);
 
 void EGEAPI movewindow(int x, int y, bool redraw = true);	//“∆∂Ø¥∞ø⁄
 void EGEAPI resizewindow(int width, int height);			//÷ÿ…Ë¥∞ø⁄≥ﬂ¥Á
@@ -715,8 +723,6 @@ void EGEAPI setbkcolor(color_t color, PIMAGE pimg = NULL);      // …Ë÷√µ±«∞ªÊÕº±
 void EGEAPI setbkcolor_f(color_t color, PIMAGE pimg = NULL);    // øÏÀŸ…Ë÷√µ±«∞ªÊÕº±≥æ∞…´£®÷ª…Ë÷√≤ªªÊª≠£©
 void EGEAPI setfontbkcolor(color_t color, PIMAGE pimg = NULL);  // …Ë÷√µ±«∞Œƒ◊÷±≥æ∞…´
 void EGEAPI setbkmode(int iBkMode, PIMAGE pimg = NULL);         // …Ë÷√±≥æ∞ªÏ∫œƒ£ Ω(0=OPAQUE, 1=TRANSPARENT)
-void EGEAPI setinitmode(int mode = INIT_DEFAULT, int x = CW_USEDEFAULT, int y = CW_USEDEFAULT); //…Ë÷√≥ı ºªØƒ£ Ω£¨mode=0Œ™∆’Õ®£¨1Œ™Œﬁ±ﬂøÚ¥∞ø⁄£¨xy «≥ı º¥∞ø⁄◊¯±Í
-int  EGEAPI attachHWND(HWND hWnd);
 
 // ºÊ»›∫Í
 #define RGBtoGRAY   rgb2gray

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -72,7 +72,7 @@ static DWORD    g_windowstyle = WS_OVERLAPPED|WS_CAPTION|WS_SYSMENU|WS_MINIMIZEB
 static DWORD    g_windowexstyle = WS_EX_LEFT|WS_EX_LTRREADING;
 static int      g_windowpos_x = CW_USEDEFAULT;
 static int      g_windowpos_y = CW_USEDEFAULT;
-static int      g_initoption  = -1;
+static int      g_initoption  = INIT_DEFAULT;
 static HWND     g_attach_hwnd = 0;
 static WNDPROC  DefWindowProcFunc = NULL;
 
@@ -1239,7 +1239,7 @@ void initicon(void) {
 }
 
 void
-initgraph(int *gdriver, int *gmode, char *path) {
+initgraph(int *gdriver, int *gmode, const char *path) {
 	struct _graph_setting * pg = &graph_setting;
 
 	pg->exit_flag = 0;
@@ -1257,8 +1257,6 @@ initgraph(int *gdriver, int *gmode, char *path) {
 	}
 
 	//初始化环境
-	if (g_initoption == -1)
-		setinitmode();
 	setmode(*gdriver, *gmode);	
 	init_img_page(pg);
 
@@ -1304,12 +1302,8 @@ initgraph(int *gdriver, int *gmode, char *path) {
 void
 initgraph(int Width, int Height, int Flag) {
 	int g = TRUECOLORSIZE, m = (Width) | (Height<<16);
-
-	if (g_initoption == -1)
-		setinitmode(Flag);
-
-	initgraph(&g, &m, (char*)"");
-	//using flag;
+	setinitmode(Flag);
+	initgraph(&g, &m, "");
 }
 
 void
@@ -1410,6 +1404,10 @@ setinitmode(int mode, int x, int y) {
 	}
 	g_windowpos_x = x;
 	g_windowpos_y = y;
+}
+
+int getinitmode() {
+	return g_initoption;
 }
 
 // 获取当前版本 ####


### PR DESCRIPTION
不带 Flag 参数仅用长宽调用 `initgraph`，则在 Release 配置启动时显示 Logo，在 Release 时则不显示。

新增函数 `getinitmode`。

将兼容 BGI 的 `initgraph` 重载版本的 `path` 参数类型改为 `const char*`。

