### PR TITLE
fix(graphics): 修复 inputbox_getline 界面发黑的问题

### DIFF
--- a/src/egegapi.cpp
+++ b/src/egegapi.cpp
@@ -2468,6 +2468,7 @@ inputbox_getline(LPCWSTR title, LPCWSTR text, LPWSTR buf, int len) {
 
 	bg.getimage(0, 0, getwidth(), getheight());
 	window.resize(w, h);
+	cleardevice(&window);
 	buf[0] = 0;
 
 	lock_window = pg->lock_window;


### PR DESCRIPTION
解决 #44 
问题来自 EGE20.08 取消了 `resize` 会执行 `cleardevice` 的假设。