### PR TITLE
当IDE出于智能提示的目的读取ege.h时，不包含windows.h

### DIFF
--- a/man/api/index.htm
+++ b/man/api/index.htm
@@ -26,6 +26,8 @@
 <a href="rand/index.htm">随机函数</a>
 
 <a href="other/index.htm">其它函数</a>
+
+<a href="macro/index.htm">其他预定义常量</a>
 </font>
 </pre>
 

--- a/man/api/macro/index.htm
+++ b/man/api/macro/index.htm
@@ -1,0 +1,19 @@
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <title>其它函数</title>
+</head>
+<body>
+
+<pre><font size="4"><a href="../../index.htm">主页</a>-＞<a href="../index.htm">库函数目录</a>-＞其它预定义常量</font>
+<font size="4">
+其他预定义常量列表
+<table width="100%" border="1" align="center" style="font-size: 16;">
+<tr><td bgcolor="#8080FF">预定义常量（宏）</td><td bgcolor="#8080FF">说明</td></tr>
+<tr><td>_EGE_FOR_AUTO_CODE_COMPLETETION_ONLY_</td><td>当该常量被定义时,表示当前是IDE为了智能提示功能，正在解析ege.h文件获取相关定义。<br />
+	在这种情况下ege.h将不会包含windows.h，以尽量减少出现在智能提示列表中的windows api定义数量。</td></tr>
+</table>
+</font>
+</pre>
+
+</body>
+

--- a/man/api/macro/index.htm
+++ b/man/api/macro/index.htm
@@ -9,7 +9,7 @@
 其他预定义常量列表
 <table width="100%" border="1" align="center" style="font-size: 16;">
 <tr><td bgcolor="#8080FF">预定义常量（宏）</td><td bgcolor="#8080FF">说明</td></tr>
-<tr><td>_EGE_FOR_AUTO_CODE_COMPLETETION_ONLY_</td><td>当该常量被定义时,表示当前是IDE为了智能提示功能，正在解析ege.h文件获取相关定义。<br />
+<tr><td>EGE_FOR_AUTO_CODE_COMPLETETION_ONLY</td><td>当该常量被定义时,表示当前是IDE为了智能提示功能，正在解析ege.h文件获取相关定义。<br />
 	在这种情况下ege.h将不会包含windows.h，以尽量减少出现在智能提示列表中的windows api定义数量。</td></tr>
 </table>
 </font>

--- a/src/ege.h
+++ b/src/ege.h
@@ -81,7 +81,7 @@
 
 #endif
 
-#if defined(_EGE_FOR_AUTO_CODE_COMPLETETION_ONLY_)
+#if defined(EGE_FOR_AUTO_CODE_COMPLETETION_ONLY)
 #include <windef.h>
 #include <winuser.h>
 #include <wingdi.h>

--- a/src/ege.h
+++ b/src/ege.h
@@ -81,7 +81,13 @@
 
 #endif
 
-#include "windows.h"
+#if defined(_EGE_FOR_AUTO_CODE_COMPLETETION_ONLY_)
+#include <windef.h>
+#include <winuser.h>
+#include <wingdi.h>
+#else
+#include <windows.h>	
+#endif
 
 #if defined(_MSC_VER) && _MSC_VER <= 1200 && !defined(SetWindowLongPtr)
 #	define SetWindowLongPtrW   SetWindowLongW


### PR DESCRIPTION
目前ege.h中直接include windows.h文件，导致IDE智能提示时会显示大部分的Windows API，这其实是不必要的。

因此，当_EGE_FOR_AUTO_CODE_COMPLETETION_ONLY_宏被定义时，ege.h不包含windows.h而只包含winuser.h, wingdi.h和windef.h

这样不会影响EGE的正常编译和使用