### PR TITLE
将EGE_GDIPLUS宏放到ege.h中

### DIFF
--- a/src/ege.h
+++ b/src/ege.h
@@ -138,6 +138,8 @@
 #	endif
 #endif
 
+#define EGE_GDIPLUS     //启用GDIPLUS
+
 #define SHOWCONSOLE             1       // 进入图形模式时，保留控制台的显示
 #define EGERGBA(r, g, b, a)     ( ((r)<<16) | ((g)<<8) | (b) | ((a)<<24) )
 #define EGERGB(r, g, b)         EGERGBA(r, g, b, 0xFF)
@@ -769,6 +771,7 @@ void EGEAPI fillpoly_gradient(int numpoints, const ege_colpoint* polypoints, PIM
 void EGEAPI floodfill(int x, int y, int border, PIMAGE pimg = NULL);                // 按边界颜色填充区域
 void EGEAPI floodfillsurface(int x, int y, color_t areacolor, PIMAGE pimg = NULL);  // 按起始点颜色填充区域
 
+#ifdef EGE_GDIPLUS
 // 高级绘图函数（带AA）
 // ege new_api
 void EGEAPI ege_enable_aa(bool enable, PIMAGE pimg = NULL);
@@ -805,6 +808,7 @@ void EGEAPI ege_puttexture(PCIMAGE srcimg, float x, float y, float w, float h, P
 void EGEAPI ege_puttexture(PCIMAGE srcimg, ege_rect dest, PIMAGE pimg = NULL);
 void EGEAPI ege_puttexture(PCIMAGE srcimg, ege_rect dest, ege_rect src, PIMAGE pimg = NULL);
 //
+#endif
 
 //int  EGEAPI Begin2d();
 //void EGEAPI EndRender();

--- a/src/ege_head.h
+++ b/src/ege_head.h
@@ -111,8 +111,6 @@
 #define EGE_FORCEINLINE   __attribute__((always_inline)) inline
 #endif
 
-#define EGE_GDIPLUS // 使用gdi+函数扩展
-
 #ifdef EGE_GDIPLUS
 #	include <gdiplus.h>
 #endif


### PR DESCRIPTION
目前ege_系列高级作图函数定义在ege.h中，实现在egegapi.cpp中。
在实现部分，会根据EGE_GDIPLUS宏是否定义来决定是否实现；而在ege.h中并未做该判断。
因此，将EGE_GDIPLUS宏放到ege.h中，并根据该宏是否被定义来决定是否要定义ege_系列高级作图函数

btw:
不知道为什么git老是认为我修改了putimage_rotatetransparent的定义。实际上没有修改；我直接从github上手工下载一个最新的ege.h来做修改，它仍然认为putimage_rotatetransparent这部分有变化。不理解了