### PR TITLE
在Image对象中缓存Graphics和Pen对象

### DIFF
--- a/demo/egealpha.cpp
+++ b/demo/egealpha.cpp
@@ -20,6 +20,9 @@ int main()
     setlinestyle(CENTER_LINE,0,1,img);
     setlinewidth(10,img);
     ege_line(100,100,400,400,img);
+    setcolor(EGEACOLOR(255,GREEN),img);    
+    setlinestyle(DOTTED_LINE,0,1,img);
+    setlinewidth(5,img);    
     ege_ellipse(200,100,200,200,img);		
     putimage_withalpha(NULL,img,0,0);
     

--- a/demo/egealpha.cpp
+++ b/demo/egealpha.cpp
@@ -3,32 +3,40 @@
 
 int main()
 {
-    initgraph( 640, 480 );
+	initgraph( 640, 480 );
 
 	setbkcolor(WHITE);
 	setcolor(BLUE);
 	setfillcolor(BLUE);
 	bar(100,100,600,400);
-	
+
 	PIMAGE img=newimage(640,480);
 	//set backgrounds alpha to 0
-    setbkcolor(EGERGBA(0,0,0,0),img);
-    
-    //draw shapes with alpha to 255
-    setfillcolor(EGEACOLOR(255,RED),img);
-    setcolor(EGEACOLOR(255,RED),img);
-    setlinestyle(CENTER_LINE,0,1,img);
-    setlinewidth(10,img);
-    ege_line(100,100,400,400,img);
-    setcolor(EGEACOLOR(255,GREEN),img);    
-    setlinestyle(DOTTED_LINE,0,1,img);
-    setlinewidth(5,img);    
-    ege_ellipse(200,100,200,200,img);		
-    putimage_withalpha(NULL,img,0,0);
-    
-    //putimage(0,0,img);
-    delimage(img);
-    
-    getch();
-    return 0;
+	setbkcolor(EGERGBA(0,0,0,0),img);
+
+	//draw shapes with alpha to 255
+	setfillcolor(EGEACOLOR(255,RED),img);
+	setcolor(EGEACOLOR(255,RED),img);
+	setlinestyle(CENTER_LINE,0,1,img);
+	setlinewidth(10,img);
+	ege_line(100,100,400,400,img);
+	//change color
+	setcolor(EGEACOLOR(255,GREEN),img);
+	setlinestyle(DOTTED_LINE,0,1,img);
+	setlinewidth(5,img);
+	ege_ellipse(200,100,200,200,img);
+	//set fill color
+	setfillcolor(EGEACOLOR(255,LIGHTMAGENTA),img);
+	ege_fillellipse(10,10,50,50,img);
+
+	setfillcolor(EGEACOLOR(255,LIGHTBLUE),img);
+	ege_fillellipse(100,10,50,50,img);
+
+	putimage_withalpha(NULL,img,0,0);
+
+	//putimage(0,0,img);
+	delimage(img);
+
+	getch();
+	return 0;
 }

--- a/src/ege.h
+++ b/src/ege.h
@@ -454,6 +454,7 @@ typedef enum mouse_msg_e {
 	mouse_msg_move      = 0x40,
 	mouse_msg_wheel     = 0x80,
 }mouse_msg_e;
+
 typedef enum mouse_flag_e {
 	mouse_flag_left     = 1,
 	mouse_flag_right    = 2,

--- a/src/ege.h
+++ b/src/ege.h
@@ -454,6 +454,7 @@ typedef enum mouse_msg_e {
 	mouse_msg_move      = 0x40,
 	mouse_msg_wheel     = 0x80,
 }mouse_msg_e;
+
 typedef enum mouse_flag_e {
 	mouse_flag_left     = 1,
 	mouse_flag_right    = 2,
@@ -461,13 +462,6 @@ typedef enum mouse_flag_e {
 	mouse_flag_shift    = 0x100,
 	mouse_flag_ctrl     = 0x200,
 }mouse_flag_e;
-
-typedef enum pattern_type_e {
-	pattern_none            = 0,
-	pattern_lineargradient  = 1,
-	pattern_pathgradient    = 2,
-	pattern_texture         = 3,
-}pattern_type_e;
 
 typedef DWORD color_t;
 

--- a/src/ege.h
+++ b/src/ege.h
@@ -462,13 +462,6 @@ typedef enum mouse_flag_e {
 	mouse_flag_ctrl     = 0x200,
 }mouse_flag_e;
 
-typedef enum pattern_type_e {
-	pattern_none            = 0,
-	pattern_lineargradient  = 1,
-	pattern_pathgradient    = 2,
-	pattern_texture         = 3,
-}pattern_type_e;
-
 typedef DWORD color_t;
 
 struct viewporttype {

--- a/src/ege.h
+++ b/src/ege.h
@@ -454,7 +454,6 @@ typedef enum mouse_msg_e {
 	mouse_msg_move      = 0x40,
 	mouse_msg_wheel     = 0x80,
 }mouse_msg_e;
-
 typedef enum mouse_flag_e {
 	mouse_flag_left     = 1,
 	mouse_flag_right    = 2,
@@ -462,6 +461,13 @@ typedef enum mouse_flag_e {
 	mouse_flag_shift    = 0x100,
 	mouse_flag_ctrl     = 0x200,
 }mouse_flag_e;
+
+typedef enum pattern_type_e {
+	pattern_none            = 0,
+	pattern_lineargradient  = 1,
+	pattern_pathgradient    = 2,
+	pattern_texture         = 3,
+}pattern_type_e;
 
 typedef DWORD color_t;
 

--- a/src/ege_head.h
+++ b/src/ege_head.h
@@ -274,8 +274,8 @@ public:
 	color_t     m_fillcolor;
 private:
 #ifdef EGE_GDIPLUS
-	std::shared_ptr<Gdiplus::Graphics> m_graphics;
-	std::shared_ptr<Gdiplus::Pen> m_pen;
+	std::unique_ptr<Gdiplus::Graphics> m_graphics;
+	std::unique_ptr<Gdiplus::Pen> m_pen;
 #endif
 	bool        m_aa;
 	void initimage(HDC refDC, int width, int height);
@@ -310,17 +310,17 @@ public:
 	color_t* getbuffer() const {return (color_t*)m_pBuffer;}
 #ifdef EGE_GDIPLUS
 	//TODO: thread safe
-	inline std::shared_ptr<Gdiplus::Graphics> getGraphics() {
+	inline const std::unique_ptr<Gdiplus::Graphics>& getGraphics() {
 		if (nullptr == m_graphics.get()) {
-			m_graphics=std::make_shared<Gdiplus::Graphics>(m_hDC);
+			m_graphics=std::make_unique<Gdiplus::Graphics>(m_hDC);
 			m_graphics->SetPixelOffsetMode(Gdiplus::PixelOffsetModeHalf);
 			m_graphics->SetSmoothingMode(m_aa? Gdiplus::SmoothingModeAntiAlias : Gdiplus::SmoothingModeNone);
 		}
 		return m_graphics;
 	}
-	inline std::shared_ptr<Gdiplus::Pen> getPen() {
+	inline const std::unique_ptr<Gdiplus::Pen>& getPen() {
 		if (nullptr == m_pen.get()) {
-			m_pen = std::make_shared<Gdiplus::Pen>(m_color,m_linewidth);
+			m_pen = std::make_unique<Gdiplus::Pen>(m_color,m_linewidth);
 			m_pen->SetDashStyle(linestyle_to_dashstyle(m_linestyle.linestyle));
 		}
 		return m_pen;

--- a/src/ege_head.h
+++ b/src/ege_head.h
@@ -310,7 +310,7 @@ public:
 	color_t* getbuffer() const {return (color_t*)m_pBuffer;}
 #ifdef EGE_GDIPLUS
 	//TODO: thread safe
-	std::shared_ptr<Gdiplus::Graphics> getGraphics() {
+	inline std::shared_ptr<Gdiplus::Graphics> getGraphics() {
 		if (nullptr == m_graphics.get()) {
 			m_graphics=std::make_shared<Gdiplus::Graphics>(m_hDC);
 			m_graphics->SetPixelOffsetMode(Gdiplus::PixelOffsetModeHalf);
@@ -318,7 +318,7 @@ public:
 		}
 		return m_graphics;
 	}
-	std::shared_ptr<Gdiplus::Pen> getPen() {
+	inline std::shared_ptr<Gdiplus::Pen> getPen() {
 		if (nullptr == m_pen.get()) {
 			m_pen = std::make_shared<Gdiplus::Pen>(m_color,m_linewidth);
 			m_pen->SetDashStyle(linestyle_to_dashstyle(m_linestyle.linestyle));
@@ -326,7 +326,7 @@ public:
 		return m_pen;
 	}
 #endif
-	void enable_anti_alias(bool enable){
+	inline void enable_anti_alias(bool enable){
 		m_aa = enable;
 #ifdef EGE_GDIPLUS
 		if (nullptr != m_graphics.get()) {
@@ -334,7 +334,6 @@ public:
 		}
 #endif
 	}
-
 
 	int  resize(int width, int height);
 	void copyimage(PCIMAGE pSrcImg);

--- a/src/ege_head.h
+++ b/src/ege_head.h
@@ -115,7 +115,6 @@
 
 #ifdef EGE_GDIPLUS
 #	include <gdiplus.h>
-#	include <memory>
 #endif
 
 #define QUEUE_LEN               1024
@@ -245,19 +244,7 @@ struct EGEMSG {
 };
 
 #ifdef EGE_GDIPLUS
-inline Gdiplus::DashStyle linestyle_to_dashstyle(int linestyle) {
-	switch(linestyle){
-		case SOLID_LINE:
-			return Gdiplus::DashStyleSolid;
-		case PS_DASH:
-			return Gdiplus::DashStyleDash;
-		case PS_DOT:
-			return Gdiplus::DashStyleDot;
-		case PS_DASHDOT:
-			return Gdiplus::DashStyleDashDot;
-	}
-	return Gdiplus::DashStyleSolid;
-}
+Gdiplus::DashStyle linestyle_to_dashstyle(int linestyle);
 #endif
 
 // 定义图像对象
@@ -274,9 +261,9 @@ public:
 	color_t     m_fillcolor;
 private:
 #ifdef EGE_GDIPLUS
-	std::shared_ptr<Gdiplus::Graphics> m_graphics;
-	std::shared_ptr<Gdiplus::Pen> m_pen;
-	std::shared_ptr<Gdiplus::Brush> m_brush;
+	Gdiplus::Graphics* m_graphics;
+	Gdiplus::Pen* m_pen;
+	Gdiplus::Brush* m_brush;
 #endif
 	bool        m_aa;
 	void initimage(HDC refDC, int width, int height);
@@ -307,44 +294,12 @@ public:
 	color_t* getbuffer() const {return (color_t*)m_pBuffer;}
 #ifdef EGE_GDIPLUS
 	//TODO: thread safe?
-	inline const std::shared_ptr<Gdiplus::Graphics>& getGraphics() {
-		if (m_graphics.get() == nullptr) {
-			m_graphics=std::make_shared<Gdiplus::Graphics>(m_hDC);
-			m_graphics->SetPixelOffsetMode(Gdiplus::PixelOffsetModeHalf);
-			m_graphics->SetSmoothingMode(m_aa? Gdiplus::SmoothingModeAntiAlias : Gdiplus::SmoothingModeNone);
-		}
-		return m_graphics;
-	}
-	inline const std::shared_ptr<Gdiplus::Pen>& getPen() {
-		if (m_pen.get() == nullptr) {
-			m_pen = std::make_shared<Gdiplus::Pen>(m_color,m_linewidth);
-			m_pen->SetDashStyle(linestyle_to_dashstyle(m_linestyle.linestyle));
-		}
-		return m_pen;
-	}
-	inline const std::shared_ptr<Gdiplus::Brush>& getBrush() {
-		if (m_brush.get() == nullptr) {
-			m_brush = std::make_shared<Gdiplus::SolidBrush>(m_fillcolor);
-		}
-		return m_brush;
-	}
-	inline void set_pattern(Gdiplus::Brush* brush) {
-		if (NULL == brush) {
-			m_brush.reset();
-		} else {
-			m_brush.reset(brush);
-		}
-	}
+	Gdiplus::Graphics* getGraphics();
+	Gdiplus::Pen* getPen();
+	Gdiplus::Brush* getBrush();
+	void set_pattern(Gdiplus::Brush* brush);
 #endif
-
-inline void enable_anti_alias(bool enable){
-	m_aa = enable;
-#ifdef EGE_GDIPLUS
-	if (m_graphics.get() != nullptr) {
-		m_graphics->SetSmoothingMode(m_aa? Gdiplus::SmoothingModeAntiAlias : Gdiplus::SmoothingModeNone);
-	}
-#endif
-}
+	void enable_anti_alias(bool enable);
 
 	int  resize(int width, int height);
 	void copyimage(PCIMAGE pSrcImg);

--- a/src/ege_head.h
+++ b/src/ege_head.h
@@ -115,7 +115,7 @@
 
 #ifdef EGE_GDIPLUS
 #	include <gdiplus.h>
-#   include <memory>
+#	include <memory>
 #endif
 
 #define QUEUE_LEN               1024

--- a/src/ege_head.h
+++ b/src/ege_head.h
@@ -274,8 +274,8 @@ public:
 	color_t     m_fillcolor;
 private:
 #ifdef EGE_GDIPLUS
-	std::unique_ptr<Gdiplus::Graphics> m_graphics;
-	std::unique_ptr<Gdiplus::Pen> m_pen;
+	std::shared_ptr<Gdiplus::Graphics> m_graphics;
+	std::shared_ptr<Gdiplus::Pen> m_pen;
 #endif
 	bool        m_aa;
 	void initimage(HDC refDC, int width, int height);
@@ -310,17 +310,17 @@ public:
 	color_t* getbuffer() const {return (color_t*)m_pBuffer;}
 #ifdef EGE_GDIPLUS
 	//TODO: thread safe
-	inline const std::unique_ptr<Gdiplus::Graphics>& getGraphics() {
+	inline const std::shared_ptr<Gdiplus::Graphics>& getGraphics() {
 		if (nullptr == m_graphics.get()) {
-			m_graphics=std::make_unique<Gdiplus::Graphics>(m_hDC);
+			m_graphics=std::make_shared<Gdiplus::Graphics>(m_hDC);
 			m_graphics->SetPixelOffsetMode(Gdiplus::PixelOffsetModeHalf);
 			m_graphics->SetSmoothingMode(m_aa? Gdiplus::SmoothingModeAntiAlias : Gdiplus::SmoothingModeNone);
 		}
 		return m_graphics;
 	}
-	inline const std::unique_ptr<Gdiplus::Pen>& getPen() {
+	inline const std::shared_ptr<Gdiplus::Pen>& getPen() {
 		if (nullptr == m_pen.get()) {
-			m_pen = std::make_unique<Gdiplus::Pen>(m_color,m_linewidth);
+			m_pen = std::make_shared<Gdiplus::Pen>(m_color,m_linewidth);
 			m_pen->SetDashStyle(linestyle_to_dashstyle(m_linestyle.linestyle));
 		}
 		return m_pen;

--- a/src/egegapi.cpp
+++ b/src/egegapi.cpp
@@ -776,7 +776,7 @@ static void update_pen(PIMAGE img) {
 
 	// why update pen not in IMAGE???
 #ifdef EGE_GDIPLUS
-	const std::shared_ptr<Gdiplus::Pen>& pen=img->getPen();
+	Gdiplus::Pen* pen=img->getPen();
 	pen->SetColor(img->m_color);
 	pen->SetWidth(img->m_linewidth);
 	pen->SetDashStyle(linestyle_to_dashstyle(img->m_linestyle.linestyle));
@@ -2020,6 +2020,19 @@ clearviewport(PIMAGE pimg) {
 }
 
 #ifdef EGE_GDIPLUS
+Gdiplus::DashStyle linestyle_to_dashstyle(int linestyle){
+	switch(linestyle){
+	case SOLID_LINE:
+		return Gdiplus::DashStyleSolid;
+	case PS_DASH:
+		return Gdiplus::DashStyleDash;
+	case PS_DOT:
+		return Gdiplus::DashStyleDot;
+	case PS_DASHDOT:
+		return Gdiplus::DashStyleDashDot;
+	}
+	return Gdiplus::DashStyleSolid;
+}
 
 void
 ege_line(float x1, float y1, float x2, float y2, PIMAGE pimg) {
@@ -2027,9 +2040,9 @@ ege_line(float x1, float y1, float x2, float y2, PIMAGE pimg) {
 	if (img) {
 		if (img->m_linestyle.linestyle == PS_NULL) 
 			return;
-		const std::shared_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
-		const std::shared_ptr<Gdiplus::Pen>& pen=img->getPen();
-		graphics->DrawLine(pen.get(), x1, y1, x2, y2);
+		Gdiplus::Graphics* graphics=img->getGraphics();
+		Gdiplus::Pen* pen=img->getPen();
+		graphics->DrawLine(pen, x1, y1, x2, y2);
 	}
 	CONVERT_IMAGE_END;
 }
@@ -2040,9 +2053,9 @@ ege_drawpoly(int numpoints, ege_point* polypoints, PIMAGE pimg) {
 	if (img) {
 		if (img->m_linestyle.linestyle == PS_NULL)
 			return;
-		const std::shared_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
-		const std::shared_ptr<Gdiplus::Pen>& pen=img->getPen();
-		graphics->DrawLines(pen.get(), (Gdiplus::PointF*)polypoints, numpoints);
+		Gdiplus::Graphics* graphics=img->getGraphics();
+		Gdiplus::Pen* pen=img->getPen();
+		graphics->DrawLines(pen, (Gdiplus::PointF*)polypoints, numpoints);
 	}
 	CONVERT_IMAGE_END;
 }
@@ -2053,9 +2066,9 @@ ege_drawcurve(int numpoints, ege_point* polypoints, PIMAGE pimg) {
 	if (img) {
 		if (img->m_linestyle.linestyle == PS_NULL)
 			return;
-		const std::shared_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
-		const std::shared_ptr<Gdiplus::Pen>& pen=img->getPen();
-		graphics->DrawCurve(pen.get(), (Gdiplus::PointF*)polypoints, numpoints);
+		Gdiplus::Graphics* graphics=img->getGraphics();
+		Gdiplus::Pen* pen=img->getPen();
+		graphics->DrawCurve(pen, (Gdiplus::PointF*)polypoints, numpoints);
 	}
 	CONVERT_IMAGE_END;
 }
@@ -2066,9 +2079,9 @@ ege_rectangle(float x, float y, float w, float h, PIMAGE pimg) {
 	if (img) {
 		if (img->m_linestyle.linestyle == PS_NULL)
 			return;
-		const std::shared_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
-		const std::shared_ptr<Gdiplus::Pen>& pen=img->getPen();
-		graphics->DrawRectangle(pen.get(), x, y, w, h);
+		Gdiplus::Graphics* graphics=img->getGraphics();
+		Gdiplus::Pen* pen=img->getPen();
+		graphics->DrawRectangle(pen, x, y, w, h);
 	}
 	CONVERT_IMAGE_END;
 }
@@ -2079,9 +2092,9 @@ ege_ellipse(float x, float y, float w, float h, PIMAGE pimg) {
 	if (img) {
 		if (img->m_linestyle.linestyle == PS_NULL)
 			return;
-		const std::shared_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
-		const std::shared_ptr<Gdiplus::Pen>& pen=img->getPen();
-		graphics->DrawEllipse(pen.get(), x, y, w, h);
+		Gdiplus::Graphics* graphics=img->getGraphics();
+		Gdiplus::Pen* pen=img->getPen();
+		graphics->DrawEllipse(pen, x, y, w, h);
 	}
 	CONVERT_IMAGE_END;
 }
@@ -2092,9 +2105,9 @@ ege_pie(float x, float y, float w, float h, float stangle, float sweepAngle, PIM
 	if (img) {
 		if (img->m_linestyle.linestyle == PS_NULL)
 			return;
-		const std::shared_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
-		const std::shared_ptr<Gdiplus::Pen>& pen=img->getPen();
-		graphics->DrawPie(pen.get(), x, y, w, h, stangle, sweepAngle);
+		Gdiplus::Graphics* graphics=img->getGraphics();
+		Gdiplus::Pen* pen=img->getPen();
+		graphics->DrawPie(pen, x, y, w, h, stangle, sweepAngle);
 	}
 	CONVERT_IMAGE_END;
 }
@@ -2105,9 +2118,9 @@ ege_arc(float x, float y, float w, float h, float stangle, float sweepAngle, PIM
 	if (img) {
 		if (img->m_linestyle.linestyle == PS_NULL)
 			return;
-		const std::shared_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
-		const std::shared_ptr<Gdiplus::Pen>& pen=img->getPen();
-		graphics->DrawArc(pen.get(), x, y, w, h, stangle, sweepAngle);
+		Gdiplus::Graphics* graphics=img->getGraphics();
+		Gdiplus::Pen* pen=img->getPen();
+		graphics->DrawArc(pen, x, y, w, h, stangle, sweepAngle);
 	}
 	CONVERT_IMAGE_END;
 }
@@ -2118,9 +2131,9 @@ ege_bezier(int numpoints, ege_point* polypoints, PIMAGE pimg) {
 	if (img) {
 		if (img->m_linestyle.linestyle == PS_NULL)
 			return;
-		const std::shared_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
-		const std::shared_ptr<Gdiplus::Pen>& pen=img->getPen();
-		graphics->DrawBeziers(pen.get(), (Gdiplus::PointF*)polypoints, numpoints);
+		Gdiplus::Graphics* graphics=img->getGraphics();
+		Gdiplus::Pen* pen=img->getPen();
+		graphics->DrawBeziers(pen, (Gdiplus::PointF*)polypoints, numpoints);
 	}
 	CONVERT_IMAGE_END;
 }
@@ -2205,9 +2218,9 @@ void
 ege_fillpoly(int numpoints, ege_point* polypoints, PIMAGE pimg) {
 	PIMAGE img = CONVERT_IMAGE(pimg);
 	if (img) {
-		const std::shared_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
-		const std::shared_ptr<Gdiplus::Brush>& brush=img->getBrush();
-		graphics->FillPolygon(brush.get(), (Gdiplus::PointF*)polypoints, numpoints);
+		Gdiplus::Graphics* graphics=img->getGraphics();
+		Gdiplus::Brush* brush=img->getBrush();
+		graphics->FillPolygon(brush, (Gdiplus::PointF*)polypoints, numpoints);
 	}
 	CONVERT_IMAGE_END;
 }
@@ -2216,9 +2229,9 @@ void
 ege_fillrect(float x, float y, float w, float h, PIMAGE pimg) {
 	PIMAGE img = CONVERT_IMAGE(pimg);
 	if (img) {
-		const std::shared_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
-		const std::shared_ptr<Gdiplus::Brush>& brush=img->getBrush();
-		graphics->FillRectangle(brush.get(), x, y, w, h);
+		Gdiplus::Graphics* graphics=img->getGraphics();
+		Gdiplus::Brush* brush=img->getBrush();
+		graphics->FillRectangle(brush, x, y, w, h);
 	}
 	CONVERT_IMAGE_END;
 }
@@ -2227,9 +2240,9 @@ void
 ege_fillellipse(float x, float y, float w, float h, PIMAGE pimg) {
 	PIMAGE img = CONVERT_IMAGE(pimg);
 	if (img) {
-		const std::shared_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
-		const std::shared_ptr<Gdiplus::Brush>& brush=img->getBrush();
-		graphics->FillEllipse(brush.get(), x, y, w, h);
+		Gdiplus::Graphics* graphics=img->getGraphics();
+		Gdiplus::Brush* brush=img->getBrush();
+		graphics->FillEllipse(brush, x, y, w, h);
 	}
 	CONVERT_IMAGE_END;
 }
@@ -2238,9 +2251,9 @@ void
 ege_fillpie(float x, float y, float w, float h, float stangle, float sweepAngle, PIMAGE pimg) {
 	PIMAGE img = CONVERT_IMAGE(pimg);
 	if (img) {
-		const std::shared_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
-		const std::shared_ptr<Gdiplus::Brush>& brush=img->getBrush();
-		graphics->FillPie(brush.get(), x, y, w, h, stangle, sweepAngle);
+		Gdiplus::Graphics* graphics=img->getGraphics();
+		Gdiplus::Brush* brush=img->getBrush();
+		graphics->FillPie(brush, x, y, w, h, stangle, sweepAngle);
 	}
 	CONVERT_IMAGE_END;
 }
@@ -2294,7 +2307,7 @@ ege_puttexture(PCIMAGE srcimg, ege_rect dest, ege_rect src, PIMAGE pimg) {
 	PIMAGE img = CONVERT_IMAGE(pimg);
 	if (img) {
 		if (srcimg->m_texture) {
-			const std::shared_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
+			Gdiplus::Graphics* graphics=img->getGraphics();
 			/*
 			Gdiplus::ImageAttributes ia;
 			Gdiplus::ColorMatrix mx = {
@@ -2326,7 +2339,7 @@ ege_puttexture(PCIMAGE srcimg, ege_rect dest, ege_rect src, PIMAGE pimg) {
 
 // TODO: ¥ÌŒÛ¥¶¿Ì
 static void ege_drawtext_p(LPCWSTR textstring, float x, float y, PIMAGE img) {
-	const std::shared_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
+	Gdiplus::Graphics* graphics=img->getGraphics();
 
 	HFONT hf = (HFONT)GetCurrentObject(img->m_hDC, OBJ_FONT);
 	LOGFONT lf;

--- a/src/egegapi.cpp
+++ b/src/egegapi.cpp
@@ -773,6 +773,15 @@ static void update_pen(PIMAGE img) {
 	if (hpen) {
 		DeleteObject(SelectObject(img->m_hDC, hpen));
 	}
+
+	// why update pen not in IMAGE???
+#ifdef EGE_GDIPLUS
+	std::shared_ptr<Gdiplus::Pen> pen=img->getPen();
+	pen->SetColor(img->m_color);
+	pen->SetWidth(img->m_linewidth);
+	pen->SetDashStyle(linestyle_to_dashstyle(img->m_linestyle.linestyle));
+#endif
+
 }
 
 void
@@ -2006,34 +2015,15 @@ clearviewport(PIMAGE pimg) {
 
 #ifdef EGE_GDIPLUS
 
-static Gdiplus::DashStyle linestyle_to_dashstyle(int linestyle) {
-	switch(linestyle){
-		case SOLID_LINE:
-			return Gdiplus::DashStyleSolid;
-		case PS_DASH:
-			return Gdiplus::DashStyleDash;
-		case PS_DOT:
-			return Gdiplus::DashStyleDot;
-		case PS_DASHDOT:
-			return Gdiplus::DashStyleDashDot;
-	}
-	return Gdiplus::DashStyleSolid;
-}
-
 void
 ege_line(float x1, float y1, float x2, float y2, PIMAGE pimg) {
 	PIMAGE img = CONVERT_IMAGE(pimg);
 	if (img) {
 		if (img->m_linestyle.linestyle == PS_NULL) 
 			return;
-		Gdiplus::Graphics graphics(img->getdc());
-		Gdiplus::Pen pen(img->m_color, img->m_linewidth);
-		pen.SetDashStyle(linestyle_to_dashstyle(img->m_linestyle.linestyle));
-		graphics.SetPixelOffsetMode(Gdiplus::PixelOffsetModeHalf);
-		if (img->m_aa) {
-			graphics.SetSmoothingMode(Gdiplus::SmoothingModeAntiAlias);
-		}
-		graphics.DrawLine(&pen, x1, y1, x2, y2);
+		std::shared_ptr<Gdiplus::Graphics> graphics=img->getGraphics();
+		std::shared_ptr<Gdiplus::Pen> pen=img->getPen();
+		graphics->DrawLine(pen.get(), x1, y1, x2, y2);
 	}
 	CONVERT_IMAGE_END;
 }
@@ -2042,16 +2032,11 @@ void
 ege_drawpoly(int numpoints, ege_point* polypoints, PIMAGE pimg) {
 	PIMAGE img = CONVERT_IMAGE(pimg);
 	if (img) {
-		if (img->m_linestyle.linestyle == PS_NULL) 
+		if (img->m_linestyle.linestyle == PS_NULL)
 			return;
-		Gdiplus::Graphics graphics(img->getdc());
-		Gdiplus::Pen pen(img->m_color, img->m_linewidth);
-		pen.SetDashStyle(linestyle_to_dashstyle(img->m_linestyle.linestyle));
-		graphics.SetPixelOffsetMode(Gdiplus::PixelOffsetModeHalf);
-		if (img->m_aa) {
-			graphics.SetSmoothingMode(Gdiplus::SmoothingModeAntiAlias);
-		}
-		graphics.DrawLines(&pen, (Gdiplus::PointF*)polypoints, numpoints);
+		std::shared_ptr<Gdiplus::Graphics> graphics=img->getGraphics();
+		std::shared_ptr<Gdiplus::Pen> pen=img->getPen();
+		graphics->DrawLines(pen.get(), (Gdiplus::PointF*)polypoints, numpoints);
 	}
 	CONVERT_IMAGE_END;
 }
@@ -2060,16 +2045,11 @@ void
 ege_drawcurve(int numpoints, ege_point* polypoints, PIMAGE pimg) {
 	PIMAGE img = CONVERT_IMAGE(pimg);
 	if (img) {
-		if (img->m_linestyle.linestyle == PS_NULL) 
+		if (img->m_linestyle.linestyle == PS_NULL)
 			return;
-		Gdiplus::Graphics graphics(img->getdc());
-		Gdiplus::Pen pen(img->m_color, img->m_linewidth);
-		pen.SetDashStyle(linestyle_to_dashstyle(img->m_linestyle.linestyle));		
-		graphics.SetPixelOffsetMode(Gdiplus::PixelOffsetModeHalf);
-		if (img->m_aa) {
-			graphics.SetSmoothingMode(Gdiplus::SmoothingModeAntiAlias);
-		}
-		graphics.DrawCurve(&pen, (Gdiplus::PointF*)polypoints, numpoints);
+		std::shared_ptr<Gdiplus::Graphics> graphics=img->getGraphics();
+		std::shared_ptr<Gdiplus::Pen> pen=img->getPen();
+		graphics->DrawCurve(pen.get(), (Gdiplus::PointF*)polypoints, numpoints);
 	}
 	CONVERT_IMAGE_END;
 }
@@ -2078,16 +2058,11 @@ void
 ege_rectangle(float x, float y, float w, float h, PIMAGE pimg) {
 	PIMAGE img = CONVERT_IMAGE(pimg);
 	if (img) {
-		if (img->m_linestyle.linestyle == PS_NULL) 
+		if (img->m_linestyle.linestyle == PS_NULL)
 			return;
-		Gdiplus::Graphics graphics(img->getdc());
-		Gdiplus::Pen pen(img->m_color, img->m_linewidth);
-		pen.SetDashStyle(linestyle_to_dashstyle(img->m_linestyle.linestyle));	
-		graphics.SetPixelOffsetMode(Gdiplus::PixelOffsetModeHalf);
-		if (img->m_aa) {
-			graphics.SetSmoothingMode(Gdiplus::SmoothingModeAntiAlias);
-		}
-		graphics.DrawRectangle(&pen, x, y, w, h);
+		std::shared_ptr<Gdiplus::Graphics> graphics=img->getGraphics();
+		std::shared_ptr<Gdiplus::Pen> pen=img->getPen();
+		graphics->DrawRectangle(pen.get(), x, y, w, h);
 	}
 	CONVERT_IMAGE_END;
 }
@@ -2096,16 +2071,11 @@ void
 ege_ellipse(float x, float y, float w, float h, PIMAGE pimg) {
 	PIMAGE img = CONVERT_IMAGE(pimg);
 	if (img) {
-		if (img->m_linestyle.linestyle == PS_NULL) 
+		if (img->m_linestyle.linestyle == PS_NULL)
 			return;
-		Gdiplus::Graphics graphics(img->getdc());
-		Gdiplus::Pen pen(img->m_color, img->m_linewidth);
-		pen.SetDashStyle(linestyle_to_dashstyle(img->m_linestyle.linestyle));			
-		graphics.SetPixelOffsetMode(Gdiplus::PixelOffsetModeHalf);
-		if (img->m_aa) {
-			graphics.SetSmoothingMode(Gdiplus::SmoothingModeAntiAlias);
-		}
-		graphics.DrawEllipse(&pen, x, y, w, h);
+		std::shared_ptr<Gdiplus::Graphics> graphics=img->getGraphics();
+		std::shared_ptr<Gdiplus::Pen> pen=img->getPen();
+		graphics->DrawEllipse(pen.get(), x, y, w, h);
 	}
 	CONVERT_IMAGE_END;
 }
@@ -2114,16 +2084,11 @@ void
 ege_pie(float x, float y, float w, float h, float stangle, float sweepAngle, PIMAGE pimg) {
 	PIMAGE img = CONVERT_IMAGE(pimg);
 	if (img) {
-		if (img->m_linestyle.linestyle == PS_NULL) 
+		if (img->m_linestyle.linestyle == PS_NULL)
 			return;
-		Gdiplus::Graphics graphics(img->getdc());
-		Gdiplus::Pen pen(img->m_color, img->m_linewidth);
-		pen.SetDashStyle(linestyle_to_dashstyle(img->m_linestyle.linestyle));				
-		graphics.SetPixelOffsetMode(Gdiplus::PixelOffsetModeHalf);
-		if (img->m_aa) {
-			graphics.SetSmoothingMode(Gdiplus::SmoothingModeAntiAlias);
-		}
-		graphics.DrawPie(&pen, x, y, w, h, stangle, sweepAngle);
+		std::shared_ptr<Gdiplus::Graphics> graphics=img->getGraphics();
+		std::shared_ptr<Gdiplus::Pen> pen=img->getPen();
+		graphics->DrawPie(pen.get(), x, y, w, h, stangle, sweepAngle);
 	}
 	CONVERT_IMAGE_END;
 }
@@ -2132,16 +2097,11 @@ void
 ege_arc(float x, float y, float w, float h, float stangle, float sweepAngle, PIMAGE pimg) {
 	PIMAGE img = CONVERT_IMAGE(pimg);
 	if (img) {
-		if (img->m_linestyle.linestyle == PS_NULL) 
+		if (img->m_linestyle.linestyle == PS_NULL)
 			return;
-		Gdiplus::Graphics graphics(img->getdc());
-		Gdiplus::Pen pen(img->m_color, img->m_linewidth);
-		pen.SetDashStyle(linestyle_to_dashstyle(img->m_linestyle.linestyle));		
-		graphics.SetPixelOffsetMode(Gdiplus::PixelOffsetModeHalf);
-		if (img->m_aa) {
-			graphics.SetSmoothingMode(Gdiplus::SmoothingModeAntiAlias);
-		}
-		graphics.DrawArc(&pen, x, y, w, h, stangle, sweepAngle);
+		std::shared_ptr<Gdiplus::Graphics> graphics=img->getGraphics();
+		std::shared_ptr<Gdiplus::Pen> pen=img->getPen();
+		graphics->DrawArc(pen.get(), x, y, w, h, stangle, sweepAngle);
 	}
 	CONVERT_IMAGE_END;
 }
@@ -2150,16 +2110,11 @@ void
 ege_bezier(int numpoints, ege_point* polypoints, PIMAGE pimg) {
 	PIMAGE img = CONVERT_IMAGE(pimg);
 	if (img) {
-		if (img->m_linestyle.linestyle == PS_NULL) 
+		if (img->m_linestyle.linestyle == PS_NULL)
 			return;
-		Gdiplus::Graphics graphics(img->getdc());
-		Gdiplus::Pen pen(img->m_color, img->m_linewidth);
-		pen.SetDashStyle(linestyle_to_dashstyle(img->m_linestyle.linestyle));		
-		graphics.SetPixelOffsetMode(Gdiplus::PixelOffsetModeHalf);
-		if (img->m_aa) {
-			graphics.SetSmoothingMode(Gdiplus::SmoothingModeAntiAlias);
-		}
-		graphics.DrawBeziers(&pen, (Gdiplus::PointF*)polypoints, numpoints);
+		std::shared_ptr<Gdiplus::Graphics> graphics=img->getGraphics();
+		std::shared_ptr<Gdiplus::Pen> pen=img->getPen();
+		graphics->DrawBeziers(pen.get(), (Gdiplus::PointF*)polypoints, numpoints);
 	}
 	CONVERT_IMAGE_END;
 }
@@ -2246,16 +2201,12 @@ void
 ege_fillpoly(int numpoints, ege_point* polypoints, PIMAGE pimg) {
 	PIMAGE img = CONVERT_IMAGE(pimg);
 	if (img) {
-		Gdiplus::Graphics graphics(img->getdc());
-		graphics.SetPixelOffsetMode(Gdiplus::PixelOffsetModeHalf);
-		if (img->m_aa) {
-			graphics.SetSmoothingMode(Gdiplus::SmoothingModeAntiAlias);
-		}
+		std::shared_ptr<Gdiplus::Graphics> graphics = img->getGraphics();
 		if (img->m_pattern_obj) {
-			graphics.FillPolygon((Gdiplus::Brush*)img->m_pattern_obj, (Gdiplus::PointF*)polypoints, numpoints);
+			graphics->FillPolygon((Gdiplus::Brush*)img->m_pattern_obj, (Gdiplus::PointF*)polypoints, numpoints);
 		} else {
 			Gdiplus::SolidBrush brush(img->m_fillcolor);
-			graphics.FillPolygon(&brush, (Gdiplus::PointF*)polypoints, numpoints);
+			graphics->FillPolygon(&brush, (Gdiplus::PointF*)polypoints, numpoints);
 		}
 	}
 	CONVERT_IMAGE_END;
@@ -2265,16 +2216,12 @@ void
 ege_fillrect(float x, float y, float w, float h, PIMAGE pimg) {
 	PIMAGE img = CONVERT_IMAGE(pimg);
 	if (img) {
-		Gdiplus::Graphics graphics(img->getdc());
-		graphics.SetPixelOffsetMode(Gdiplus::PixelOffsetModeHalf);
-		if (img->m_aa) {
-			graphics.SetSmoothingMode(Gdiplus::SmoothingModeAntiAlias);
-		}
+		std::shared_ptr<Gdiplus::Graphics> graphics = img->getGraphics();
 		if (img->m_pattern_obj) {
-			graphics.FillRectangle((Gdiplus::Brush*)img->m_pattern_obj, x, y, w, h);
+			graphics->FillRectangle((Gdiplus::Brush*)img->m_pattern_obj, x, y, w, h);
 		} else {
 			Gdiplus::SolidBrush brush(img->m_fillcolor);
-			graphics.FillRectangle(&brush, x, y, w, h);
+			graphics->FillRectangle(&brush, x, y, w, h);
 		}
 	}
 	CONVERT_IMAGE_END;
@@ -2284,16 +2231,12 @@ void
 ege_fillellipse(float x, float y, float w, float h, PIMAGE pimg) {
 	PIMAGE img = CONVERT_IMAGE(pimg);
 	if (img) {
-		Gdiplus::Graphics graphics(img->getdc());
-		graphics.SetPixelOffsetMode(Gdiplus::PixelOffsetModeHalf);
-		if (img->m_aa) {
-			graphics.SetSmoothingMode(Gdiplus::SmoothingModeAntiAlias);
-		}
+		std::shared_ptr<Gdiplus::Graphics> graphics = img->getGraphics();
 		if (img->m_pattern_obj) {
-			graphics.FillEllipse((Gdiplus::Brush*)img->m_pattern_obj, x, y, w, h);
+			graphics->FillEllipse((Gdiplus::Brush*)img->m_pattern_obj, x, y, w, h);
 		} else {
 			Gdiplus::SolidBrush brush(img->m_fillcolor);
-			graphics.FillEllipse(&brush, x, y, w, h);
+			graphics->FillEllipse(&brush, x, y, w, h);
 		}
 	}
 	CONVERT_IMAGE_END;
@@ -2303,16 +2246,12 @@ void
 ege_fillpie(float x, float y, float w, float h, float stangle, float sweepAngle, PIMAGE pimg) {
 	PIMAGE img = CONVERT_IMAGE(pimg);
 	if (img) {
-		Gdiplus::Graphics graphics(img->getdc());
-		graphics.SetPixelOffsetMode(Gdiplus::PixelOffsetModeHalf);
-		if (img->m_aa) {
-			graphics.SetSmoothingMode(Gdiplus::SmoothingModeAntiAlias);
-		}
+		std::shared_ptr<Gdiplus::Graphics> graphics = img->getGraphics();
 		if (img->m_pattern_obj) {
-			graphics.FillPie((Gdiplus::Brush*)img->m_pattern_obj, x, y, w, h, stangle, sweepAngle);
+			graphics->FillPie((Gdiplus::Brush*)img->m_pattern_obj, x, y, w, h, stangle, sweepAngle);
 		} else {
 			Gdiplus::SolidBrush brush(img->m_fillcolor);
-			graphics.FillPie(&brush, x, y, w, h, stangle, sweepAngle);
+			graphics->FillPie(&brush, x, y, w, h, stangle, sweepAngle);
 		}
 	}
 	CONVERT_IMAGE_END;
@@ -2367,11 +2306,7 @@ ege_puttexture(PCIMAGE srcimg, ege_rect dest, ege_rect src, PIMAGE pimg) {
 	PIMAGE img = CONVERT_IMAGE(pimg);
 	if (img) {
 		if (srcimg->m_texture) {
-			Gdiplus::Graphics graphics(img->getdc());
-			graphics.SetPixelOffsetMode(Gdiplus::PixelOffsetModeHalf);
-			if (img->m_aa) {
-				graphics.SetSmoothingMode(Gdiplus::SmoothingModeAntiAlias);
-			}
+			std::shared_ptr<Gdiplus::Graphics> graphics = img->getGraphics();
 			/*
 			Gdiplus::ImageAttributes ia;
 			Gdiplus::ColorMatrix mx = {
@@ -2386,7 +2321,7 @@ ege_puttexture(PCIMAGE srcimg, ege_rect dest, ege_rect src, PIMAGE pimg) {
 			ia.SetColorMatrix(&mx);
 			// */
 			//graphics.SetTransform();
-			graphics.DrawImage(
+			graphics->DrawImage(
 				(Gdiplus::Image*)srcimg->m_texture,
 				Gdiplus::RectF(dest.x, dest.y, dest.w, dest.h),
 				src.x,
@@ -2403,12 +2338,7 @@ ege_puttexture(PCIMAGE srcimg, ege_rect dest, ege_rect src, PIMAGE pimg) {
 
 // TODO: ´íÎó´¦Àí
 static void ege_drawtext_p(LPCWSTR textstring, float x, float y, PIMAGE img) {
-	Gdiplus::Graphics graphics(img->m_hDC);
-	graphics.SetPixelOffsetMode(Gdiplus::PixelOffsetModeHalf);
-	if (img->m_aa) {
-		graphics.SetTextRenderingHint(Gdiplus::TextRenderingHintAntiAlias);
-	}
-
+	std::shared_ptr<Gdiplus::Graphics> graphics = img->getGraphics();
 	HFONT hf = (HFONT)GetCurrentObject(img->m_hDC, OBJ_FONT);
 	LOGFONT lf;
 	GetObject(hf, sizeof(LOGFONT), &lf);
@@ -2422,7 +2352,7 @@ static void ege_drawtext_p(LPCWSTR textstring, float x, float y, PIMAGE img) {
 	// }
 	Gdiplus::PointF origin(x, y);
 	Gdiplus::SolidBrush brush(img->m_color);
-	graphics.DrawString(textstring, -1, &font, origin, &brush);
+	graphics->DrawString(textstring, -1, &font, origin, &brush);
 	// int err;
 	// if (err = graphics.DrawString(textstring, -1, &font, origin, &brush)) {
 	// 	fprintf(stderr, "DrawString Err: %d\n", err);

--- a/src/egegapi.cpp
+++ b/src/egegapi.cpp
@@ -808,6 +808,9 @@ setfillcolor(color_t color, PIMAGE pimg) {
 	if (hbr) {
 		DeleteObject(SelectObject(img->m_hDC, hbr));
 	}
+#ifdef EGE_GDIPLUS
+	img->set_pattern(NULL);
+#endif
 	CONVERT_IMAGE_END;
 }
 
@@ -1563,6 +1566,9 @@ setfillstyle(int pattern, color_t color, PIMAGE pimg) {
 	if (hbr) {
 		DeleteObject(SelectObject(img->m_hDC, hbr));
 	}
+	#ifdef EGE_GDIPLUS
+		img->set_pattern(NULL);
+	#endif
 	CONVERT_IMAGE_END;
 }
 
@@ -2122,9 +2128,7 @@ ege_bezier(int numpoints, ege_point* polypoints, PIMAGE pimg) {
 void
 ege_setpattern_none(PIMAGE pimg) {
 	PIMAGE img = CONVERT_IMAGE(pimg);
-	if (img) {
-		img->delete_pattern();
-	}
+	img->set_pattern(NULL);
 	CONVERT_IMAGE_END;
 }
 
@@ -2138,7 +2142,7 @@ ege_setpattern_lineargradient(float x1, float y1, color_t c1, float x2, float y2
 			Gdiplus::Color(c1),
 			Gdiplus::Color(c2)
 			);
-		img->set_pattern(pbrush, pattern_lineargradient);
+		img->set_pattern(pbrush);
 	}
 	CONVERT_IMAGE_END;
 }
@@ -2157,7 +2161,7 @@ ege_setpattern_pathgradient(ege_point center, color_t centercolor,
 		pbrush->SetCenterColor(Gdiplus::Color(centercolor));
 		pbrush->SetCenterPoint(Gdiplus::PointF(center.x, center.y));
 		pbrush->SetSurroundColors((Gdiplus::Color*)pointscolor, &colcount);
-		img->set_pattern(pbrush, pattern_pathgradient);
+		img->set_pattern(pbrush);
 	}
 	CONVERT_IMAGE_END;
 }
@@ -2177,7 +2181,7 @@ ege_setpattern_ellipsegradient(ege_point center, color_t centercolor,
 		pbrush->SetCenterColor(Gdiplus::Color(centercolor));
 		pbrush->SetCenterPoint(Gdiplus::PointF(center.x, center.y));
 		pbrush->SetSurroundColors((Gdiplus::Color*)&color, &count);
-		img->set_pattern(pbrush, pattern_pathgradient);
+		img->set_pattern(pbrush);
 	}
 	CONVERT_IMAGE_END;
 }
@@ -2191,7 +2195,7 @@ ege_setpattern_texture(PIMAGE srcimg, float x, float y, float w, float h, PIMAGE
 				(Gdiplus::Image*)srcimg->m_texture,
 				Gdiplus::WrapModeTile,
 				x, y, w, h);
-			img->set_pattern(pbrush, pattern_texture);
+			img->set_pattern(pbrush);
 		}
 	}
 	CONVERT_IMAGE_END;
@@ -2202,12 +2206,8 @@ ege_fillpoly(int numpoints, ege_point* polypoints, PIMAGE pimg) {
 	PIMAGE img = CONVERT_IMAGE(pimg);
 	if (img) {
 		const std::shared_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
-		if (img->m_pattern_obj) {
-			graphics->FillPolygon((Gdiplus::Brush*)img->m_pattern_obj, (Gdiplus::PointF*)polypoints, numpoints);
-		} else {
-			Gdiplus::SolidBrush brush(img->m_fillcolor);
-			graphics->FillPolygon(&brush, (Gdiplus::PointF*)polypoints, numpoints);
-		}
+		const std::shared_ptr<Gdiplus::Brush>& brush=img->getBrush();
+		graphics->FillPolygon(brush.get(), (Gdiplus::PointF*)polypoints, numpoints);
 	}
 	CONVERT_IMAGE_END;
 }
@@ -2217,12 +2217,8 @@ ege_fillrect(float x, float y, float w, float h, PIMAGE pimg) {
 	PIMAGE img = CONVERT_IMAGE(pimg);
 	if (img) {
 		const std::shared_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
-		if (img->m_pattern_obj) {
-			graphics->FillRectangle((Gdiplus::Brush*)img->m_pattern_obj, x, y, w, h);
-		} else {
-			Gdiplus::SolidBrush brush(img->m_fillcolor);
-			graphics->FillRectangle(&brush, x, y, w, h);
-		}
+		const std::shared_ptr<Gdiplus::Brush>& brush=img->getBrush();
+		graphics->FillRectangle(brush.get(), x, y, w, h);
 	}
 	CONVERT_IMAGE_END;
 }
@@ -2232,12 +2228,8 @@ ege_fillellipse(float x, float y, float w, float h, PIMAGE pimg) {
 	PIMAGE img = CONVERT_IMAGE(pimg);
 	if (img) {
 		const std::shared_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
-		if (img->m_pattern_obj) {
-			graphics->FillEllipse((Gdiplus::Brush*)img->m_pattern_obj, x, y, w, h);
-		} else {
-			Gdiplus::SolidBrush brush(img->m_fillcolor);
-			graphics->FillEllipse(&brush, x, y, w, h);
-		}
+		const std::shared_ptr<Gdiplus::Brush>& brush=img->getBrush();
+		graphics->FillEllipse(brush.get(), x, y, w, h);
 	}
 	CONVERT_IMAGE_END;
 }
@@ -2247,12 +2239,8 @@ ege_fillpie(float x, float y, float w, float h, float stangle, float sweepAngle,
 	PIMAGE img = CONVERT_IMAGE(pimg);
 	if (img) {
 		const std::shared_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
-		if (img->m_pattern_obj) {
-			graphics->FillPie((Gdiplus::Brush*)img->m_pattern_obj, x, y, w, h, stangle, sweepAngle);
-		} else {
-			Gdiplus::SolidBrush brush(img->m_fillcolor);
-			graphics->FillPie(&brush, x, y, w, h, stangle, sweepAngle);
-		}
+		const std::shared_ptr<Gdiplus::Brush>& brush=img->getBrush();
+		graphics->FillPie(brush.get(), x, y, w, h, stangle, sweepAngle);
 	}
 	CONVERT_IMAGE_END;
 }

--- a/src/egegapi.cpp
+++ b/src/egegapi.cpp
@@ -776,7 +776,7 @@ static void update_pen(PIMAGE img) {
 
 	// why update pen not in IMAGE???
 #ifdef EGE_GDIPLUS
-	const std::unique_ptr<Gdiplus::Pen>& pen=img->getPen();
+	const std::shared_ptr<Gdiplus::Pen>& pen=img->getPen();
 	pen->SetColor(img->m_color);
 	pen->SetWidth(img->m_linewidth);
 	pen->SetDashStyle(linestyle_to_dashstyle(img->m_linestyle.linestyle));
@@ -2021,8 +2021,8 @@ ege_line(float x1, float y1, float x2, float y2, PIMAGE pimg) {
 	if (img) {
 		if (img->m_linestyle.linestyle == PS_NULL) 
 			return;
-		const std::unique_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
-		const std::unique_ptr<Gdiplus::Pen>& pen=img->getPen();
+		const std::shared_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
+		const std::shared_ptr<Gdiplus::Pen>& pen=img->getPen();
 		graphics->DrawLine(pen.get(), x1, y1, x2, y2);
 	}
 	CONVERT_IMAGE_END;
@@ -2034,8 +2034,8 @@ ege_drawpoly(int numpoints, ege_point* polypoints, PIMAGE pimg) {
 	if (img) {
 		if (img->m_linestyle.linestyle == PS_NULL)
 			return;
-		const std::unique_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
-		const std::unique_ptr<Gdiplus::Pen>& pen=img->getPen();
+		const std::shared_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
+		const std::shared_ptr<Gdiplus::Pen>& pen=img->getPen();
 		graphics->DrawLines(pen.get(), (Gdiplus::PointF*)polypoints, numpoints);
 	}
 	CONVERT_IMAGE_END;
@@ -2047,8 +2047,8 @@ ege_drawcurve(int numpoints, ege_point* polypoints, PIMAGE pimg) {
 	if (img) {
 		if (img->m_linestyle.linestyle == PS_NULL)
 			return;
-		const std::unique_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
-		const std::unique_ptr<Gdiplus::Pen>& pen=img->getPen();
+		const std::shared_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
+		const std::shared_ptr<Gdiplus::Pen>& pen=img->getPen();
 		graphics->DrawCurve(pen.get(), (Gdiplus::PointF*)polypoints, numpoints);
 	}
 	CONVERT_IMAGE_END;
@@ -2060,8 +2060,8 @@ ege_rectangle(float x, float y, float w, float h, PIMAGE pimg) {
 	if (img) {
 		if (img->m_linestyle.linestyle == PS_NULL)
 			return;
-		const std::unique_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
-		const std::unique_ptr<Gdiplus::Pen>& pen=img->getPen();
+		const std::shared_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
+		const std::shared_ptr<Gdiplus::Pen>& pen=img->getPen();
 		graphics->DrawRectangle(pen.get(), x, y, w, h);
 	}
 	CONVERT_IMAGE_END;
@@ -2073,8 +2073,8 @@ ege_ellipse(float x, float y, float w, float h, PIMAGE pimg) {
 	if (img) {
 		if (img->m_linestyle.linestyle == PS_NULL)
 			return;
-		const std::unique_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
-		const std::unique_ptr<Gdiplus::Pen>& pen=img->getPen();
+		const std::shared_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
+		const std::shared_ptr<Gdiplus::Pen>& pen=img->getPen();
 		graphics->DrawEllipse(pen.get(), x, y, w, h);
 	}
 	CONVERT_IMAGE_END;
@@ -2086,8 +2086,8 @@ ege_pie(float x, float y, float w, float h, float stangle, float sweepAngle, PIM
 	if (img) {
 		if (img->m_linestyle.linestyle == PS_NULL)
 			return;
-		const std::unique_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
-		const std::unique_ptr<Gdiplus::Pen>& pen=img->getPen();
+		const std::shared_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
+		const std::shared_ptr<Gdiplus::Pen>& pen=img->getPen();
 		graphics->DrawPie(pen.get(), x, y, w, h, stangle, sweepAngle);
 	}
 	CONVERT_IMAGE_END;
@@ -2099,8 +2099,8 @@ ege_arc(float x, float y, float w, float h, float stangle, float sweepAngle, PIM
 	if (img) {
 		if (img->m_linestyle.linestyle == PS_NULL)
 			return;
-		const std::unique_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
-		const std::unique_ptr<Gdiplus::Pen>& pen=img->getPen();
+		const std::shared_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
+		const std::shared_ptr<Gdiplus::Pen>& pen=img->getPen();
 		graphics->DrawArc(pen.get(), x, y, w, h, stangle, sweepAngle);
 	}
 	CONVERT_IMAGE_END;
@@ -2112,8 +2112,8 @@ ege_bezier(int numpoints, ege_point* polypoints, PIMAGE pimg) {
 	if (img) {
 		if (img->m_linestyle.linestyle == PS_NULL)
 			return;
-		const std::unique_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
-		const std::unique_ptr<Gdiplus::Pen>& pen=img->getPen();
+		const std::shared_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
+		const std::shared_ptr<Gdiplus::Pen>& pen=img->getPen();
 		graphics->DrawBeziers(pen.get(), (Gdiplus::PointF*)polypoints, numpoints);
 	}
 	CONVERT_IMAGE_END;
@@ -2201,7 +2201,7 @@ void
 ege_fillpoly(int numpoints, ege_point* polypoints, PIMAGE pimg) {
 	PIMAGE img = CONVERT_IMAGE(pimg);
 	if (img) {
-		const std::unique_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
+		const std::shared_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
 		if (img->m_pattern_obj) {
 			graphics->FillPolygon((Gdiplus::Brush*)img->m_pattern_obj, (Gdiplus::PointF*)polypoints, numpoints);
 		} else {
@@ -2216,7 +2216,7 @@ void
 ege_fillrect(float x, float y, float w, float h, PIMAGE pimg) {
 	PIMAGE img = CONVERT_IMAGE(pimg);
 	if (img) {
-		const std::unique_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
+		const std::shared_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
 		if (img->m_pattern_obj) {
 			graphics->FillRectangle((Gdiplus::Brush*)img->m_pattern_obj, x, y, w, h);
 		} else {
@@ -2231,7 +2231,7 @@ void
 ege_fillellipse(float x, float y, float w, float h, PIMAGE pimg) {
 	PIMAGE img = CONVERT_IMAGE(pimg);
 	if (img) {
-		const std::unique_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
+		const std::shared_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
 		if (img->m_pattern_obj) {
 			graphics->FillEllipse((Gdiplus::Brush*)img->m_pattern_obj, x, y, w, h);
 		} else {
@@ -2246,7 +2246,7 @@ void
 ege_fillpie(float x, float y, float w, float h, float stangle, float sweepAngle, PIMAGE pimg) {
 	PIMAGE img = CONVERT_IMAGE(pimg);
 	if (img) {
-		const std::unique_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
+		const std::shared_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
 		if (img->m_pattern_obj) {
 			graphics->FillPie((Gdiplus::Brush*)img->m_pattern_obj, x, y, w, h, stangle, sweepAngle);
 		} else {
@@ -2306,7 +2306,7 @@ ege_puttexture(PCIMAGE srcimg, ege_rect dest, ege_rect src, PIMAGE pimg) {
 	PIMAGE img = CONVERT_IMAGE(pimg);
 	if (img) {
 		if (srcimg->m_texture) {
-			const std::unique_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
+			const std::shared_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
 			/*
 			Gdiplus::ImageAttributes ia;
 			Gdiplus::ColorMatrix mx = {
@@ -2338,7 +2338,7 @@ ege_puttexture(PCIMAGE srcimg, ege_rect dest, ege_rect src, PIMAGE pimg) {
 
 // TODO: ¥ÌŒÛ¥¶¿Ì
 static void ege_drawtext_p(LPCWSTR textstring, float x, float y, PIMAGE img) {
-	const std::unique_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
+	const std::shared_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
 
 	HFONT hf = (HFONT)GetCurrentObject(img->m_hDC, OBJ_FONT);
 	LOGFONT lf;

--- a/src/egegapi.cpp
+++ b/src/egegapi.cpp
@@ -776,7 +776,7 @@ static void update_pen(PIMAGE img) {
 
 	// why update pen not in IMAGE???
 #ifdef EGE_GDIPLUS
-	std::shared_ptr<Gdiplus::Pen> pen=img->getPen();
+	const std::unique_ptr<Gdiplus::Pen>& pen=img->getPen();
 	pen->SetColor(img->m_color);
 	pen->SetWidth(img->m_linewidth);
 	pen->SetDashStyle(linestyle_to_dashstyle(img->m_linestyle.linestyle));
@@ -2021,8 +2021,8 @@ ege_line(float x1, float y1, float x2, float y2, PIMAGE pimg) {
 	if (img) {
 		if (img->m_linestyle.linestyle == PS_NULL) 
 			return;
-		std::shared_ptr<Gdiplus::Graphics> graphics=img->getGraphics();
-		std::shared_ptr<Gdiplus::Pen> pen=img->getPen();
+		const std::unique_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
+		const std::unique_ptr<Gdiplus::Pen>& pen=img->getPen();
 		graphics->DrawLine(pen.get(), x1, y1, x2, y2);
 	}
 	CONVERT_IMAGE_END;
@@ -2034,8 +2034,8 @@ ege_drawpoly(int numpoints, ege_point* polypoints, PIMAGE pimg) {
 	if (img) {
 		if (img->m_linestyle.linestyle == PS_NULL)
 			return;
-		std::shared_ptr<Gdiplus::Graphics> graphics=img->getGraphics();
-		std::shared_ptr<Gdiplus::Pen> pen=img->getPen();
+		const std::unique_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
+		const std::unique_ptr<Gdiplus::Pen>& pen=img->getPen();
 		graphics->DrawLines(pen.get(), (Gdiplus::PointF*)polypoints, numpoints);
 	}
 	CONVERT_IMAGE_END;
@@ -2047,8 +2047,8 @@ ege_drawcurve(int numpoints, ege_point* polypoints, PIMAGE pimg) {
 	if (img) {
 		if (img->m_linestyle.linestyle == PS_NULL)
 			return;
-		std::shared_ptr<Gdiplus::Graphics> graphics=img->getGraphics();
-		std::shared_ptr<Gdiplus::Pen> pen=img->getPen();
+		const std::unique_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
+		const std::unique_ptr<Gdiplus::Pen>& pen=img->getPen();
 		graphics->DrawCurve(pen.get(), (Gdiplus::PointF*)polypoints, numpoints);
 	}
 	CONVERT_IMAGE_END;
@@ -2060,8 +2060,8 @@ ege_rectangle(float x, float y, float w, float h, PIMAGE pimg) {
 	if (img) {
 		if (img->m_linestyle.linestyle == PS_NULL)
 			return;
-		std::shared_ptr<Gdiplus::Graphics> graphics=img->getGraphics();
-		std::shared_ptr<Gdiplus::Pen> pen=img->getPen();
+		const std::unique_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
+		const std::unique_ptr<Gdiplus::Pen>& pen=img->getPen();
 		graphics->DrawRectangle(pen.get(), x, y, w, h);
 	}
 	CONVERT_IMAGE_END;
@@ -2073,8 +2073,8 @@ ege_ellipse(float x, float y, float w, float h, PIMAGE pimg) {
 	if (img) {
 		if (img->m_linestyle.linestyle == PS_NULL)
 			return;
-		std::shared_ptr<Gdiplus::Graphics> graphics=img->getGraphics();
-		std::shared_ptr<Gdiplus::Pen> pen=img->getPen();
+		const std::unique_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
+		const std::unique_ptr<Gdiplus::Pen>& pen=img->getPen();
 		graphics->DrawEllipse(pen.get(), x, y, w, h);
 	}
 	CONVERT_IMAGE_END;
@@ -2086,8 +2086,8 @@ ege_pie(float x, float y, float w, float h, float stangle, float sweepAngle, PIM
 	if (img) {
 		if (img->m_linestyle.linestyle == PS_NULL)
 			return;
-		std::shared_ptr<Gdiplus::Graphics> graphics=img->getGraphics();
-		std::shared_ptr<Gdiplus::Pen> pen=img->getPen();
+		const std::unique_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
+		const std::unique_ptr<Gdiplus::Pen>& pen=img->getPen();
 		graphics->DrawPie(pen.get(), x, y, w, h, stangle, sweepAngle);
 	}
 	CONVERT_IMAGE_END;
@@ -2099,8 +2099,8 @@ ege_arc(float x, float y, float w, float h, float stangle, float sweepAngle, PIM
 	if (img) {
 		if (img->m_linestyle.linestyle == PS_NULL)
 			return;
-		std::shared_ptr<Gdiplus::Graphics> graphics=img->getGraphics();
-		std::shared_ptr<Gdiplus::Pen> pen=img->getPen();
+		const std::unique_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
+		const std::unique_ptr<Gdiplus::Pen>& pen=img->getPen();
 		graphics->DrawArc(pen.get(), x, y, w, h, stangle, sweepAngle);
 	}
 	CONVERT_IMAGE_END;
@@ -2112,8 +2112,8 @@ ege_bezier(int numpoints, ege_point* polypoints, PIMAGE pimg) {
 	if (img) {
 		if (img->m_linestyle.linestyle == PS_NULL)
 			return;
-		std::shared_ptr<Gdiplus::Graphics> graphics=img->getGraphics();
-		std::shared_ptr<Gdiplus::Pen> pen=img->getPen();
+		const std::unique_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
+		const std::unique_ptr<Gdiplus::Pen>& pen=img->getPen();
 		graphics->DrawBeziers(pen.get(), (Gdiplus::PointF*)polypoints, numpoints);
 	}
 	CONVERT_IMAGE_END;
@@ -2201,7 +2201,7 @@ void
 ege_fillpoly(int numpoints, ege_point* polypoints, PIMAGE pimg) {
 	PIMAGE img = CONVERT_IMAGE(pimg);
 	if (img) {
-		std::shared_ptr<Gdiplus::Graphics> graphics = img->getGraphics();
+		const std::unique_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
 		if (img->m_pattern_obj) {
 			graphics->FillPolygon((Gdiplus::Brush*)img->m_pattern_obj, (Gdiplus::PointF*)polypoints, numpoints);
 		} else {
@@ -2216,7 +2216,7 @@ void
 ege_fillrect(float x, float y, float w, float h, PIMAGE pimg) {
 	PIMAGE img = CONVERT_IMAGE(pimg);
 	if (img) {
-		std::shared_ptr<Gdiplus::Graphics> graphics = img->getGraphics();
+		const std::unique_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
 		if (img->m_pattern_obj) {
 			graphics->FillRectangle((Gdiplus::Brush*)img->m_pattern_obj, x, y, w, h);
 		} else {
@@ -2231,7 +2231,7 @@ void
 ege_fillellipse(float x, float y, float w, float h, PIMAGE pimg) {
 	PIMAGE img = CONVERT_IMAGE(pimg);
 	if (img) {
-		std::shared_ptr<Gdiplus::Graphics> graphics = img->getGraphics();
+		const std::unique_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
 		if (img->m_pattern_obj) {
 			graphics->FillEllipse((Gdiplus::Brush*)img->m_pattern_obj, x, y, w, h);
 		} else {
@@ -2246,7 +2246,7 @@ void
 ege_fillpie(float x, float y, float w, float h, float stangle, float sweepAngle, PIMAGE pimg) {
 	PIMAGE img = CONVERT_IMAGE(pimg);
 	if (img) {
-		std::shared_ptr<Gdiplus::Graphics> graphics = img->getGraphics();
+		const std::unique_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
 		if (img->m_pattern_obj) {
 			graphics->FillPie((Gdiplus::Brush*)img->m_pattern_obj, x, y, w, h, stangle, sweepAngle);
 		} else {
@@ -2306,7 +2306,7 @@ ege_puttexture(PCIMAGE srcimg, ege_rect dest, ege_rect src, PIMAGE pimg) {
 	PIMAGE img = CONVERT_IMAGE(pimg);
 	if (img) {
 		if (srcimg->m_texture) {
-			std::shared_ptr<Gdiplus::Graphics> graphics = img->getGraphics();
+			const std::unique_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
 			/*
 			Gdiplus::ImageAttributes ia;
 			Gdiplus::ColorMatrix mx = {
@@ -2338,7 +2338,8 @@ ege_puttexture(PCIMAGE srcimg, ege_rect dest, ege_rect src, PIMAGE pimg) {
 
 // TODO: ¥ÌŒÛ¥¶¿Ì
 static void ege_drawtext_p(LPCWSTR textstring, float x, float y, PIMAGE img) {
-	std::shared_ptr<Gdiplus::Graphics> graphics = img->getGraphics();
+	const std::unique_ptr<Gdiplus::Graphics>& graphics=img->getGraphics();
+
 	HFONT hf = (HFONT)GetCurrentObject(img->m_hDC, OBJ_FONT);
 	LOGFONT lf;
 	GetObject(hf, sizeof(LOGFONT), &lf);

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -43,12 +43,11 @@ void IMAGE::reset() {
 	memset(&m_linestyle, 0, sizeof(m_linestyle));
 	m_linewidth = 0.0f;
 	m_bk_color = 0;
-	m_pattern_obj = NULL;
-	m_pattern_type = 0;
 	m_texture = NULL;
 #ifdef EGE_GDIPLUS
-	m_graphics = nullptr;
-	m_pen = nullptr;
+	m_graphics.reset();
+	m_pen.reset();
+	m_brush.reset();
 #endif
 }
 
@@ -88,7 +87,6 @@ IMAGE::IMAGE(const IMAGE &img) {
 
 IMAGE::~IMAGE() {
 	gentexture(false);
-	delete_pattern();
 	deleteimage();
 }
 
@@ -99,28 +97,6 @@ void IMAGE::inittest(const WCHAR* strCallFunction) const {
 		MessageBoxW(graph_setting.hwnd, str, L"EGE ERROR message", MB_ICONSTOP);
 		ExitProcess((UINT)grError);
 	}
-}
-
-void
-IMAGE::set_pattern(void* obj, int type) {
-	delete_pattern();
-	m_pattern_type = type;
-	m_pattern_obj = obj;
-}
-
-void
-IMAGE::delete_pattern() {
-	if (m_pattern_obj == NULL) return;
-
-	if (m_pattern_type == pattern_none) {
-	} else if (m_pattern_type == pattern_lineargradient) {
-		delete (Gdiplus::LinearGradientBrush*)m_pattern_obj;
-	} else if (m_pattern_type == pattern_pathgradient) {
-		delete (Gdiplus::PathGradientBrush*)m_pattern_obj;
-	} else if (m_pattern_type == pattern_texture) {
-		delete (Gdiplus::TextureBrush*)m_pattern_obj;
-	}
-	m_pattern_obj = NULL;
 }
 
 void
@@ -142,8 +118,9 @@ IMAGE::gentexture(bool gen) {
 int
 IMAGE::deleteimage() {
 #ifdef EGE_GDIPLUS
-	m_graphics = nullptr;
-	m_pen = nullptr;
+	m_graphics.reset();
+	m_pen.reset();
+	m_brush.reset();
 #endif
 
 	HBITMAP hbmp  = (HBITMAP)GetCurrentObject(m_hDC, OBJ_BITMAP);
@@ -223,7 +200,7 @@ void IMAGE::setdefaultattribute() {
 	setlinestyle(PS_SOLID, 0, 1, this);
 	settextjustify(LEFT_TEXT, TOP_TEXT, this);
 	setfont(16, 0, "SimSun", this);
-	ege_enable_aa(false, this);
+	enable_anti_alias(false);
 }
 
 int

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -46,6 +46,10 @@ void IMAGE::reset() {
 	m_pattern_obj = NULL;
 	m_pattern_type = 0;
 	m_texture = NULL;
+#ifdef EGE_GDIPLUS
+	m_graphics = nullptr;
+	m_pen = nullptr;
+#endif
 }
 
 void IMAGE::construct(int width, int height) {
@@ -137,6 +141,11 @@ IMAGE::gentexture(bool gen) {
 
 int
 IMAGE::deleteimage() {
+#ifdef EGE_GDIPLUS
+	m_graphics = nullptr;
+	m_pen = nullptr;
+#endif
+
 	HBITMAP hbmp  = (HBITMAP)GetCurrentObject(m_hDC, OBJ_BITMAP);
 	HBRUSH  hbr   = (HBRUSH)GetCurrentObject(m_hDC, OBJ_BRUSH);
 	HPEN    hpen  = (HPEN)GetCurrentObject(m_hDC, OBJ_PEN);
@@ -149,7 +158,7 @@ IMAGE::deleteimage() {
 	DeleteObject(hbr);
 	DeleteObject(hpen);
 	DeleteObject(hfont);
-	
+
 	return 0;
 }
 
@@ -251,6 +260,13 @@ IMAGE::operator = (const IMAGE &img) {
 	this->copyimage(&img);
 	return *this;
 }
+
+#ifdef EGE_GDIPLUS
+
+
+
+
+#endif
 
 void
 IMAGE::copyimage(PCIMAGE pSrcImg) {
@@ -2730,6 +2746,8 @@ HDC getHDC(PCIMAGE pImg) {
 	return img->getdc();
 }
 
+
+
 int
 resize(PIMAGE pDstImg, int width, int height) {
 	
@@ -2990,7 +3008,7 @@ savepng(PCIMAGE pimg, LPCWSTR filename, int bAlpha) {
 void
 ege_enable_aa(bool enable, PIMAGE pimg) {
 	PIMAGE img  = CONVERT_IMAGE(pimg);
-	img->m_aa = enable;
+	img->enable_anti_alias(enable);
 	CONVERT_IMAGE_END;
 }
 

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -45,9 +45,9 @@ void IMAGE::reset() {
 	m_bk_color = 0;
 	m_texture = NULL;
 #ifdef EGE_GDIPLUS
-	m_graphics.reset();
-	m_pen.reset();
-	m_brush.reset();
+	m_graphics=NULL;
+	m_pen=NULL;
+	m_brush=NULL;
 #endif
 }
 
@@ -118,9 +118,15 @@ IMAGE::gentexture(bool gen) {
 int
 IMAGE::deleteimage() {
 #ifdef EGE_GDIPLUS
-	m_graphics.reset();
-	m_pen.reset();
-	m_brush.reset();
+	if (NULL!=m_graphics)
+		delete m_graphics;
+	m_graphics=NULL;
+	if (NULL!=m_pen)
+		delete m_pen;
+	m_pen=NULL;
+	if (NULL!=m_brush)
+		delete m_brush;
+	m_brush=NULL;
 #endif
 
 	HBITMAP hbmp  = (HBITMAP)GetCurrentObject(m_hDC, OBJ_BITMAP);
@@ -201,6 +207,47 @@ void IMAGE::setdefaultattribute() {
 	settextjustify(LEFT_TEXT, TOP_TEXT, this);
 	setfont(16, 0, "SimSun", this);
 	enable_anti_alias(false);
+}
+
+#ifdef EGE_GDIPLUS
+
+Gdiplus::Graphics*  IMAGE::getGraphics() {
+	if (NULL == m_graphics) {
+		m_graphics=new Gdiplus::Graphics(m_hDC);
+		m_graphics->SetPixelOffsetMode(Gdiplus::PixelOffsetModeHalf);
+		m_graphics->SetSmoothingMode(m_aa? Gdiplus::SmoothingModeAntiAlias : Gdiplus::SmoothingModeNone);
+	}
+	return m_graphics;
+}
+Gdiplus::Pen* IMAGE::getPen() {
+	if (NULL == m_pen) {
+		m_pen = new Gdiplus::Pen(m_color,m_linewidth);
+		m_pen->SetDashStyle(linestyle_to_dashstyle(m_linestyle.linestyle));
+	}
+	return m_pen;
+}
+Gdiplus::Brush* IMAGE::getBrush() {
+	if (NULL == m_brush) {
+		m_brush = new Gdiplus::SolidBrush(m_fillcolor);
+	}
+	return m_brush;
+}
+
+void IMAGE::set_pattern(Gdiplus::Brush* brush) {
+	if (NULL != m_brush) {
+		delete m_brush;
+	}
+	m_brush = brush;
+}
+#endif
+
+void IMAGE::enable_anti_alias(bool enable){
+	m_aa = enable;
+#ifdef EGE_GDIPLUS
+	if (NULL != m_graphics) {
+		m_graphics->SetSmoothingMode(m_aa? Gdiplus::SmoothingModeAntiAlias : Gdiplus::SmoothingModeNone);
+	}
+#endif
 }
 
 int

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -261,13 +261,6 @@ IMAGE::operator = (const IMAGE &img) {
 	return *this;
 }
 
-#ifdef EGE_GDIPLUS
-
-
-
-
-#endif
-
 void
 IMAGE::copyimage(PCIMAGE pSrcImg) {
 	inittest(L"IMAGE::copyimage");

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -2739,8 +2739,6 @@ HDC getHDC(PCIMAGE pImg) {
 	return img->getdc();
 }
 
-
-
 int
 resize(PIMAGE pDstImg, int width, int height) {
 	


### PR DESCRIPTION
目前所有的ege_系列函数都在内部创建一个Graphics对象，处理后释放。
这会影响图像绘制时的性能。

这个Patch在Image对象内部缓存了Graphics对象和Pen对象。ege_系列函数在绘图时会使用这两个缓存的对象，不在创建新对象。

为了节省资源，这两个对象使用延迟加载，只有在第一次使用时才会被创建。

为了提高速度，相关函数做成了inline的形式。

请大家审核吧