### PR TITLE
增加ege_drawimage和ege_transform系列函数

### DIFF
--- a/demo/ege_new_drawimage.cpp
+++ b/demo/ege_new_drawimage.cpp
@@ -1,0 +1,61 @@
+#include <graphics.h>
+
+int main()
+{
+	initgraph( 800, 600 );
+	// draw background image
+	setbkcolor(WHITE);
+	setcolor( BLACK);
+	setfillcolor( BLUE );
+	
+	for (int i=0;i<12;i++) {
+		bar(0,i*50,800,i*50+20);
+	}
+   
+   	//image to be rotated and put
+	PIMAGE  img = newimage(200,200);
+	setbkcolor(EGERGBA(0,0,0,0),img);
+	setcolor(RED,img);
+	setfillcolor(YELLOW,img);
+	
+	ege_point points[4];
+	points[0].x=100;
+	points[0].y=50;
+	points[1].x=50;
+	points[1].y=150;
+	points[2].x=150;
+	points[2].y=150;
+	points[3].x=100;
+	points[3].y=50;
+	ege_fillpoly(3,points,img);
+	ege_drawpoly(4,points,img);
+	
+	//draw without scale
+	ege_drawimage(img,0,0);
+	
+	//draw with scale
+	ege_drawimage(img,200,0,400,300,0,0,200,200);
+
+	//draw with transform
+	ege_transform_matrix m;
+	//save old transform
+	ege_get_transform(&m);
+	ege_transform_translate(400,450); //center of bottom half window
+	ege_transform_rotate(45.0); // rotate
+	ege_transform_translate(-getwidth(img)/2, -getheight(img)/2); // center of src image
+	ege_drawimage(img,0,0); 
+	//restore old transform
+	ege_set_transform(&m);
+	
+	//use it to clear transform
+	//ege_transform_reset();
+	
+	//draw to test transform is correctly restored
+	ege_drawimage(img,600,400);
+	
+	getch();
+		
+	delimage(img);
+
+	return 0;
+}

--- a/man/api/draw/ege_drawimage.htm
+++ b/man/api/draw/ege_drawimage.htm
@@ -1,0 +1,57 @@
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <title>ege_drawimage</title>
+</head>
+<body>
+
+<pre><font size="4"><a href="../../index.htm">主页</a>-＞<a href="../index.htm">库函数目录</a>-＞<a href="index.htm">绘制图形相关函数</a>-＞ege_drawimage</font>
+<font size="4">
+<font size="5" color="#0000FF"><strong>功能：</strong></font>
+这个函数用来将一个图像绘制到另一个图像或屏幕上（使用alpha混合方式）。
+
+<font size="5" color="#0000FF"><strong>声明：</strong></font>
+
+<pre><font color=#008000>// 绘制图像</font>
+<font color=#0000FF>void </font><font color=#008080>ege_drawimage</font>(
+    <font color=#800080>PCIMAGE </font>srcimg,        <font color=#008000>// 源图像指针</font>
+    <font color=#0000FF>int </font>dstX,              <font color=#008000>// 绘制位置的 x 坐标</font>
+    <font color=#0000FF>int </font>dstY,              <font color=#008000>// 绘制位置的 y 坐标</font>
+    <font color=#800080>PCIMAGE </font>pimg = <font color=#800080>NULL  </font><font color=#008000>//目标图像指针，NULL表示绘制到屏幕</font>
+);
+
+<font color=#008000>// 绘制图像(拉伸)</font>
+<font color=#0000FF>void </font><font color=#008080>ege_drawimage</font>(
+    <font color=#800080>PCIMAGE </font>srcimg,        <font color=#008000>// 源图像指针</font>
+    <font color=#0000FF>int </font>dstX,              <font color=#008000>// 绘制位置的 x 坐标</font>
+    <font color=#0000FF>int </font>dstY,              <font color=#008000>// 绘制位置的 y 坐标</font>
+    <font color=#0000FF>int </font>dstWidth,          <font color=#008000>// 绘制的宽度</font>
+    <font color=#0000FF>int </font>dstHeight,         <font color=#008000>// 绘制的高度</font>
+    <font color=#0000FF>int </font>srcX,              <font color=#008000>// 绘制内容在 IMAGE 对象中的左上角 x 坐标</font>
+    <font color=#0000FF>int </font>srcY,              <font color=#008000>// 绘制内容在 IMAGE 对象中的左上角 y 坐标</font>
+    <font color=#0000FF>int </font>srcWidth,          <font color=#008000>// 绘制内容在源 IMAGE 对象中的宽度</font>
+    <font color=#0000FF>int </font>srcHeight,         <font color=#008000>// 绘制内容在源 IMAGE 对象中的高度</font>
+    <font color=#800080>PCIMAGE </font>pimg = <font color=#800080>NULL  </font><font color=#008000>//目标图像指针，NULL表示绘制到屏幕</font>
+);
+</pre>
+
+<font size="5" color="#0000FF"><strong>参数：</strong></font>
+（详见各重载函数原型内的注释）
+
+<font size="5" color="#0000FF"><strong>返回值：</strong></font>
+（无）
+
+<font size="5" color="#0000FF"><strong>示例：</strong></font>
+以下局部代码读取 c:\test.png 绘制在屏幕左上角：
+<pre><font color=#800080>PIMAGE </font>img = <font color=#008080>newimage</font>();
+if (<font color=#008080>getimage</font>(img, <font color=#FF00FF>"c:\\test.png"</font>)!= grOk) {
+    <font color=#008000>//读取图片文件失败</font>
+    <font color=#008080>exit</font>(-1);
+}
+<font color=#008080>ege_putimage</font>(img,0, 0);
+<font color=#008080>delimage</font>(img);
+
+</font>
+</pre>
+
+</body>
+

--- a/man/api/draw/ege_get_transform.htm
+++ b/man/api/draw/ege_get_transform.htm
@@ -1,0 +1,43 @@
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <title>ege_get_transform</title>
+</head>
+<body>
+
+<pre><font size="4"><a href="../../index.htm">主页</a>-＞<a href="../index.htm">库函数目录</a>-＞<a href="index.htm">绘制图形相关函数</a>-＞ege_get_transform</font>
+<font size="4">
+<font size="5" color="#0000FF"><strong>功能：</strong></font>
+获取图片当前的坐标变换矩阵。
+
+<font size="5" color="#0000FF"><strong>声明：</strong></font>
+
+<pre><font color=#008000>// 获取坐标变换矩阵</font>
+<font color=#0000FF>void </font><font color=#008080>ege_get_transform</font>(
+    <font color=#0000FF>ege_transform_matrix</font>* pmatrix,              <font color=#008000>//坐标变换矩阵指针，该指针必须指向一个有效的矩阵对象</font>
+    <font color=#800080>PCIMAGE </font>pimg = <font color=#800080>NULL  </font><font color=#008000>//目标图像指针，NULL表示绘制到屏幕</font>
+);
+</pre>
+
+<font size="5" color="#0000FF"><strong>参数：</strong></font>
+（详见函数原型内的注释）
+备注：该函数通常与ege_set_transform函数配合使用。
+
+<font size="5" color="#0000FF"><strong>返回值：</strong></font>
+（无）
+
+<font size="5" color="#0000FF"><strong>示例：</strong></font>
+下面的代码将图片img沿中心点顺时针旋转45度后，复制到屏幕的中心：
+<pre>
+<font color=#800080>ege_transform_matrix</font> m;
+//保存旧的坐标变换矩阵
+<font color=#008080>ege_get_transform</font>(&m);
+<font color=#008080>ege_transform_translate</font>(<font color=#008080>getwidth</font>(),<font color=#008080>getheight</font>()); //平移到屏幕中心
+<font color=#008080>ege_transform_rotate</font>(45.0); // 顺时针旋转45度
+<font color=#008080>ege_transform_translate</font>(-<font color=#008080>getwidth</font>(img)/2, -<font color=#008080>getheight</font>(img)/2); // 平移图片img中心
+<font color=#008080>ege_drawimage</font>(img,0,0); 
+//恢复原有坐标变换
+<font color=#008080>ege_set_transform</font>(&m);
+</pre>
+
+</body>
+

--- a/man/api/draw/ege_set_transform.htm
+++ b/man/api/draw/ege_set_transform.htm
@@ -1,0 +1,43 @@
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <title>ege_set_transform</title>
+</head>
+<body>
+
+<pre><font size="4"><a href="../../index.htm">主页</a>-＞<a href="../index.htm">库函数目录</a>-＞<a href="index.htm">绘制图形相关函数</a>-＞ege_set_transform</font>
+<font size="4">
+<font size="5" color="#0000FF"><strong>功能：</strong></font>
+设置图片的坐标变换矩阵。
+
+<font size="5" color="#0000FF"><strong>声明：</strong></font>
+
+<pre><font color=#008000>// 设置坐标变换矩阵</font>
+<font color=#0000FF>void </font><font color=#008080>ege_set_transform</font>(
+    <font color=#0000FF>ege_transform_matrix</font>* pmatrix,              <font color=#008000>//坐标变换矩阵指针，该指针必须指向一个有效的矩阵对象</font>
+    <font color=#800080>PCIMAGE </font>pimg = <font color=#800080>NULL  </font><font color=#008000>//目标图像指针，NULL表示绘制到屏幕</font>
+);
+</pre>
+
+<font size="5" color="#0000FF"><strong>参数：</strong></font>
+（详见函数原型内的注释）
+备注：该函数通常与ege_get_transform函数配合使用。
+
+<font size="5" color="#0000FF"><strong>返回值：</strong></font>
+（无）
+
+<font size="5" color="#0000FF"><strong>示例：</strong></font>
+下面的代码将图片img沿中心点顺时针旋转45度后，复制到屏幕的中心：
+<pre>
+<font color=#800080>ege_transform_matrix</font> m;
+//保存旧的坐标变换矩阵
+<font color=#008080>ege_get_transform</font>(&m);
+<font color=#008080>ege_transform_translate</font>(<font color=#008080>getwidth</font>(),<font color=#008080>getheight</font>()); //平移到屏幕中心
+<font color=#008080>ege_transform_rotate</font>(45.0); // 顺时针旋转45度
+<font color=#008080>ege_transform_translate</font>(-<font color=#008080>getwidth</font>(img)/2, -<font color=#008080>getheight</font>(img)/2); // 平移图片img中心
+<font color=#008080>ege_drawimage</font>(img,0,0); 
+//恢复原有坐标变换
+<font color=#008080>ege_set_transform</font>(&m);
+</pre>
+
+</body>
+

--- a/man/api/draw/ege_transform_reset.htm
+++ b/man/api/draw/ege_transform_reset.htm
@@ -1,0 +1,41 @@
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <title>ege_transform_reset</title>
+</head>
+<body>
+
+<pre><font size="4"><a href="../../index.htm">主页</a>-＞<a href="../index.htm">库函数目录</a>-＞<a href="index.htm">绘制图形相关函数</a>-＞ege_transform_reset</font>
+<font size="4">
+<font size="5" color="#0000FF"><strong>功能：</strong></font>
+这个函数重置所有的坐标变换。
+
+<font size="5" color="#0000FF"><strong>声明：</strong></font>
+
+<pre><font color=#008000>// 重置坐标变换</font>
+<font color=#0000FF>void </font><font color=#008080>ege_transform_translate</font>(
+    <font color=#800080>PCIMAGE </font>pimg = <font color=#800080>NULL  </font><font color=#008000>//目标图像指针，NULL表示绘制到屏幕</font>
+);
+</pre>
+
+<font size="5" color="#0000FF"><strong>参数：</strong></font>
+（详见函数原型内的注释）
+
+<font size="5" color="#0000FF"><strong>返回值：</strong></font>
+（无）
+
+<font size="5" color="#0000FF"><strong>示例：</strong></font>
+下面的代码将图片img沿中心点顺时针旋转45度后，复制到屏幕的中心：
+<pre>
+<font color=#800080>ege_transform_matrix</font> m;
+//保存旧的坐标变换矩阵
+<font color=#008080>ege_get_transform</font>(&m);
+<font color=#008080>ege_transform_translate</font>(<font color=#008080>getwidth</font>(),<font color=#008080>getheight</font>()); //平移到屏幕中心
+<font color=#008080>ege_transform_rotate</font>(45.0); // 顺时针旋转45度
+<font color=#008080>ege_transform_translate</font>(-<font color=#008080>getwidth</font>(img)/2, -<font color=#008080>getheight</font>(img)/2); // 平移图片img中心
+<font color=#008080>ege_drawimage</font>(img,0,0); 
+//恢复原有坐标变换
+<font color=#008080>ege_set_transform</font>(&m);
+</pre>
+
+</body>
+

--- a/man/api/draw/ege_transform_rotate.htm
+++ b/man/api/draw/ege_transform_rotate.htm
@@ -1,0 +1,43 @@
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <title>ege_transform_rotate</title>
+</head>
+<body>
+
+<pre><font size="4"><a href="../../index.htm">主页</a>-＞<a href="../index.htm">库函数目录</a>-＞<a href="index.htm">绘制图形相关函数</a>-＞ege_transform_rotate</font>
+<font size="4">
+<font size="5" color="#0000FF"><strong>功能：</strong></font>
+这个函数将坐标轴顺时针旋转angle度。
+
+<font size="5" color="#0000FF"><strong>声明：</strong></font>
+
+<pre><font color=#008000>// 旋转坐标轴</font>
+<font color=#0000FF>void </font><font color=#008080>ege_transform_rotate</font>(
+    <font color=#0000FF>float </font>angle,              <font color=#008000>// 要旋转的角度</font>
+    <font color=#800080>PCIMAGE </font>pimg = <font color=#800080>NULL  </font><font color=#008000>//目标图像指针，NULL表示绘制到屏幕</font>
+);
+</pre>
+
+<font size="5" color="#0000FF"><strong>参数：</strong></font>
+（详见函数原型内的注释）
+备注：该函数一般与ege_transform_translate（平移坐标轴）配合使用。
+
+<font size="5" color="#0000FF"><strong>返回值：</strong></font>
+（无）
+
+<font size="5" color="#0000FF"><strong>示例：</strong></font>
+下面的代码将图片img沿中心点顺时针旋转45度后，复制到屏幕的中心：
+<pre>
+<font color=#800080>ege_transform_matrix</font> m;
+//保存旧的坐标变换矩阵
+<font color=#008080>ege_get_transform</font>(&m);
+<font color=#008080>ege_transform_translate</font>(<font color=#008080>getwidth</font>(),<font color=#008080>getheight</font>()); //平移到屏幕中心
+<font color=#008080>ege_transform_rotate</font>(45.0); // 顺时针旋转45度
+<font color=#008080>ege_transform_translate</font>(-<font color=#008080>getwidth</font>(img)/2, -<font color=#008080>getheight</font>(img)/2); // 平移图片img中心
+<font color=#008080>ege_drawimage</font>(img,0,0); 
+//恢复原有坐标变换
+<font color=#008080>ege_set_transform</font>(&m);
+</pre>
+
+</body>
+

--- a/man/api/draw/ege_transform_scale.htm
+++ b/man/api/draw/ege_transform_scale.htm
@@ -1,0 +1,43 @@
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <title>ege_transform_scale</title>
+</head>
+<body>
+
+<pre><font size="4"><a href="../../index.htm">主页</a>-＞<a href="../index.htm">库函数目录</a>-＞<a href="index.htm">绘制图形相关函数</a>-＞ege_transform_scale</font>
+<font size="4">
+<font size="5" color="#0000FF"><strong>功能：</strong></font>
+这个函数将坐标轴沿X轴缩放scale_x倍，沿Y轴缩放scale_y倍。
+
+<font size="5" color="#0000FF"><strong>声明：</strong></font>
+
+<pre><font color=#008000>// 缩放坐标轴</font>
+<font color=#0000FF>void </font><font color=#008080>ege_transform_scale</font>(
+    <font color=#0000FF>float </font>scale_x,              <font color=#008000>//X轴缩放倍数</font>
+    <font color=#0000FF>float </font>scale_y,              <font color=#008000>//Y轴缩放倍数</font>
+    <font color=#800080>PCIMAGE </font>pimg = <font color=#800080>NULL  </font><font color=#008000>//目标图像指针，NULL表示绘制到屏幕</font>
+);
+</pre>
+
+<font size="5" color="#0000FF"><strong>参数：</strong></font>
+（详见函数原型内的注释）
+
+<font size="5" color="#0000FF"><strong>返回值：</strong></font>
+（无）
+
+<font size="5" color="#0000FF"><strong>示例：</strong></font>
+下面的代码将图片img沿中心点顺时针旋转45度后，复制到屏幕的中心：
+<pre>
+<font color=#800080>ege_transform_matrix</font> m;
+//保存旧的坐标变换矩阵
+<font color=#008080>ege_get_transform</font>(&m);
+<font color=#008080>ege_transform_translate</font>(<font color=#008080>getwidth</font>(),<font color=#008080>getheight</font>()); //平移到屏幕中心
+<font color=#008080>ege_transform_rotate</font>(45.0); // 顺时针旋转45度
+<font color=#008080>ege_transform_translate</font>(-<font color=#008080>getwidth</font>(img)/2, -<font color=#008080>getheight</font>(img)/2); // 平移图片img中心
+<font color=#008080>ege_drawimage</font>(img,0,0); 
+//恢复原有坐标变换
+<font color=#008080>ege_set_transform</font>(&m);
+</pre>
+
+</body>
+

--- a/man/api/draw/ege_transform_translate.htm
+++ b/man/api/draw/ege_transform_translate.htm
@@ -1,0 +1,43 @@
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <title>ege_transform_translate</title>
+</head>
+<body>
+
+<pre><font size="4"><a href="../../index.htm">主页</a>-＞<a href="../index.htm">库函数目录</a>-＞<a href="index.htm">绘制图形相关函数</a>-＞ege_transform_translate</font>
+<font size="4">
+<font size="5" color="#0000FF"><strong>功能：</strong></font>
+这个函数将坐标轴沿X轴平移x个像素，沿Y轴平移y个像素。
+
+<font size="5" color="#0000FF"><strong>声明：</strong></font>
+
+<pre><font color=#008000>// 平移坐标轴</font>
+<font color=#0000FF>void </font><font color=#008080>ege_transform_translate</font>(
+    <font color=#0000FF>float </font>x,              <font color=#008000>//X轴平移的距离（单位为像素）</font>
+    <font color=#0000FF>float </font>y,              <font color=#008000>//Y轴平移的距离（单位为像素）</font>
+    <font color=#800080>PCIMAGE </font>pimg = <font color=#800080>NULL  </font><font color=#008000>//目标图像指针，NULL表示绘制到屏幕</font>
+);
+</pre>
+
+<font size="5" color="#0000FF"><strong>参数：</strong></font>
+（详见函数原型内的注释）
+
+<font size="5" color="#0000FF"><strong>返回值：</strong></font>
+（无）
+
+<font size="5" color="#0000FF"><strong>示例：</strong></font>
+下面的代码将图片img沿中心点顺时针旋转45度后，复制到屏幕的中心：
+<pre>
+<font color=#800080>ege_transform_matrix</font> m;
+//保存旧的坐标变换矩阵
+<font color=#008080>ege_get_transform</font>(&m);
+<font color=#008080>ege_transform_translate</font>(<font color=#008080>getwidth</font>(),<font color=#008080>getheight</font>()); //平移到屏幕中心
+<font color=#008080>ege_transform_rotate</font>(45.0); // 顺时针旋转45度
+<font color=#008080>ege_transform_translate</font>(-<font color=#008080>getwidth</font>(img)/2, -<font color=#008080>getheight</font>(img)/2); // 平移图片img中心
+<font color=#008080>ege_drawimage</font>(img,0,0); 
+//恢复原有坐标变换
+<font color=#008080>ege_set_transform</font>(&m);
+</pre>
+
+</body>
+

--- a/man/api/draw/index.htm
+++ b/man/api/draw/index.htm
@@ -68,6 +68,14 @@
 <tr><td><a href="ege_fillpoly.htm">ege_fillpoly</a></td><td>画填充多边形</td></tr>
 <tr><td><a href="ege_fillellipse.htm">ege_fillellipse</a></td><td>画填充椭圆</td></tr>
 
+<tr><td><a href="ege_drawimage.htm">ege_drawimage</a></td><td>(alpha混合)绘制图像</td></tr>
+<tr><td><a href="ege_transform_rotate.htm">ege_transform_rotate</a></td><td>旋转坐标变换</td></tr>
+<tr><td><a href="ege_transform_translate.htm">ege_translate_rotate</a></td><td>平移坐标变换</td></tr>
+<tr><td><a href="ege_transform_scale.htm">ege_transform_scale</a></td><td>缩放坐标变换</td></tr>
+<tr><td><a href="ege_transform_reset.htm">ege_transform_reset</a></td><td>重置（清除）所有坐标变换</td></tr>
+<tr><td><a href="ege_get_transform.htm">ege_get_transform</a></td><td>获取现有坐标变换矩阵</td></tr>
+<tr><td><a href="ege_set_transform.htm">ege_set_transform</a></td><td>设置坐标变换矩阵</td></tr>
+
 <tr><td><a href="ege_setpattern_none.htm">ege_setpattern_none</a></td><td>设置为默认填充模式</td></tr>
 <tr><td><a href="ege_setpattern_lineargradient.htm">ege_setpattern_lineargradient</a></td><td>设置为线性渐变填充模式</td></tr>
 <tr><td><a href="ege_setpattern_pathgradient.htm">ege_setpattern_pathgradient</a></td><td>设置为路径渐变填充模式</td></tr>

--- a/src/ege.h
+++ b/src/ege.h
@@ -801,6 +801,31 @@ void EGEAPI ege_gentexture(bool gen, PIMAGE pimg = NULL);
 void EGEAPI ege_puttexture(PCIMAGE srcimg, float x, float y, float w, float h, PIMAGE pimg = NULL);
 void EGEAPI ege_puttexture(PCIMAGE srcimg, ege_rect dest, PIMAGE pimg = NULL);
 void EGEAPI ege_puttexture(PCIMAGE srcimg, ege_rect dest, ege_rect src, PIMAGE pimg = NULL);
+
+//draw image
+void EGEAPI ege_drawimage(PCIMAGE srcimg,int dstX, int dstY,PIMAGE pimg = NULL);
+void EGEAPI ege_drawimage(PCIMAGE srcimg,int dstX, int dstY, int dstWidth, int dstHeight, int srcX, int srcY, int srcWidth, int srcHeight,PIMAGE pimg = NULL);
+
+// matrix for transformation
+typedef struct ege_transform_matrix{
+	float m11;
+	float m12;
+	float m21;
+	float m22;
+	float m31;
+	float m32;	
+}ege_transform_matrix;
+
+//transforms
+void EGEAPI ege_transform_rotate(float angle,PIMAGE pimg = NULL);
+void EGEAPI ege_transform_translate(float x,float y,PIMAGE pimg = NULL);
+void EGEAPI ege_transform_scale(float scale_x, float scale_y,PIMAGE pimg = NULL);
+void EGEAPI ege_transform_reset(PIMAGE pimg = NULL);
+void EGEAPI ege_get_transform(ege_transform_matrix* pmatrix, PIMAGE pimg = NULL);
+void EGEAPI ege_set_transform(ege_transform_matrix* const pmatrix, PIMAGE pimg = NULL);
+ege_point EGEAPI ege_transform_calc(ege_point p, PIMAGE pimg = NULL); // Calculate transformed coordination of p; 
+ege_point EGEAPI ege_transform_calc(float x, float y, PIMAGE pimg = NULL); // Calculate transformed coordination of point(x,y);
+
 //
 #endif
 

--- a/src/egegapi.cpp
+++ b/src/egegapi.cpp
@@ -2386,6 +2386,123 @@ void EGEAPI ege_drawtext(LPCWSTR textstring, float x, float y, PIMAGE pimg) {
 	CONVERT_IMAGE_END;
 }
 
+void EGEAPI ege_drawimage(PCIMAGE srcimg,int dstX, int dstY,PIMAGE pimg){
+	PIMAGE img = CONVERT_IMAGE(pimg);
+	if (img && srcimg) {
+		Gdiplus::Graphics* graphics=img->getGraphics();
+		Gdiplus::Bitmap bitmap(srcimg->getwidth(),srcimg->getheight(),4*srcimg->getwidth(),
+			PixelFormat32bppARGB,(BYTE *)(srcimg->m_pBuffer));
+		Gdiplus::Point p(dstX,dstY); 
+		graphics->DrawImage(&bitmap,p);
+	}
+	CONVERT_IMAGE_END;	
+} 
+
+void EGEAPI ege_drawimage(PCIMAGE srcimg,int dstX, int dstY, int dstWidth, int dstHeight,
+		int srcX, int srcY, int srcWidth, int srcHeight,PIMAGE pimg) {
+	PIMAGE img = CONVERT_IMAGE(pimg);
+	if (img && srcimg) {
+		Gdiplus::Graphics* graphics=img->getGraphics();
+		Gdiplus::Bitmap bitmap(srcimg->getwidth(),srcimg->getheight(),4*srcimg->getwidth(),
+			PixelFormat32bppARGB,(BYTE *)(srcimg->m_pBuffer));
+		Gdiplus::Point destPoints[3] = {
+   			Gdiplus::Point(dstX, dstY),
+   			Gdiplus::Point(dstX+dstWidth, dstY),
+   			Gdiplus::Point(dstX, dstY+dstHeight)};
+		graphics->DrawImage(&bitmap,destPoints,3,srcX,srcY,srcWidth,srcHeight,Gdiplus::UnitPixel,NULL,NULL,NULL);
+	}
+	CONVERT_IMAGE_END;			
+}
+
+void EGEAPI ege_transform_rotate(float angle,PIMAGE pimg) {
+	PIMAGE img = CONVERT_IMAGE(pimg);
+	if (img) {
+		Gdiplus::Graphics* graphics=img->getGraphics();
+		graphics->RotateTransform(angle);		
+	}
+	CONVERT_IMAGE_END;	
+}
+
+void EGEAPI ege_transform_translate(float x,float y,PIMAGE pimg) {
+	PIMAGE img = CONVERT_IMAGE(pimg);
+	if (img) {
+		Gdiplus::Graphics* graphics=img->getGraphics();
+		graphics->TranslateTransform(x,y);		
+	}
+	CONVERT_IMAGE_END;	
+}
+
+void EGEAPI ege_transform_scale(float scale_x, float scale_y,PIMAGE pimg) {
+	PIMAGE img = CONVERT_IMAGE(pimg);
+	if (img) {
+		Gdiplus::Graphics* graphics=img->getGraphics();
+		graphics->ScaleTransform(scale_x,scale_y);		
+	}
+	CONVERT_IMAGE_END;	
+}
+
+void EGEAPI ege_transform_reset(PIMAGE pimg){
+	PIMAGE img = CONVERT_IMAGE(pimg);
+	if (img) {
+		Gdiplus::Graphics* graphics=img->getGraphics();
+		graphics->ResetTransform();
+	}
+	CONVERT_IMAGE_END;	
+}
+void EGEAPI ege_get_transform(ege_transform_matrix* pmatrix, PIMAGE pimg) {
+	PIMAGE img = CONVERT_IMAGE(pimg);
+	if (img) {
+		Gdiplus::Graphics* graphics=img->getGraphics();
+		Gdiplus::Matrix m;
+		Gdiplus::REAL elements[6];
+		graphics->GetTransform(&m);
+		m.GetElements(elements);
+		pmatrix->m11 = elements[0];
+		pmatrix->m12 = elements[1];
+		pmatrix->m21 = elements[2];
+		pmatrix->m22 = elements[3];
+		pmatrix->m31 = elements[4];
+		pmatrix->m32 = elements[5];		
+	}
+	CONVERT_IMAGE_END;	
+}
+
+void EGEAPI ege_set_transform(ege_transform_matrix* const pmatrix, PIMAGE pimg) {
+	PIMAGE img = CONVERT_IMAGE(pimg);
+	if (img) {
+		Gdiplus::Graphics* graphics=img->getGraphics();
+		Gdiplus::Matrix m(pmatrix->m11,pmatrix->m12,pmatrix->m21,pmatrix->m22,pmatrix->m31,pmatrix->m32);
+		graphics->SetTransform(&m);
+	}
+	CONVERT_IMAGE_END;		
+}
+
+ege_point EGEAPI ege_transform_calc(ege_point p, PIMAGE pimg) {
+	return ege_transform_calc(p.x,p.y,pimg);		
+}
+
+ege_point EGEAPI ege_transform_calc(float x, float y, PIMAGE pimg) {
+	PIMAGE img = CONVERT_IMAGE(pimg);
+	if (img) {
+		Gdiplus::Graphics* graphics=img->getGraphics();
+		Gdiplus::Matrix m;
+		Gdiplus::REAL elements[6],m11,m12,m21,m22,m31,m32;
+		graphics->GetTransform(&m);
+		m.GetElements(elements);
+		m11 = elements[0];
+		m12 = elements[1];
+		m21 = elements[2];
+		m22 = elements[3];
+		m31 = elements[4];
+		m32 = elements[5];	
+		return {x*m11+y*m21+m31, x*m12+y*m22+m32};
+	} else {
+		return {0,0};
+	}
+	CONVERT_IMAGE_END;	
+}
+
+
 #endif //EGEGDIPLUS
 
 HWND


### PR DESCRIPTION
ege_drawimage用于实现带alpha混合的绘图，共有两个重载函数：
- 一个仅指定绘制左上角坐标，以方便使用；
- 另一个支持缩放，需要提供完整的坐标和长宽参数

ege_transform系列函数用于进行坐标变换设置，此设置对目前所有的ege绘图函数均有效。包括：
- 获取坐标变换矩阵；
- 设置坐标变换矩阵
- 平移/旋转/缩放
- 清除坐标变换设置
- 计算当前变换后点的新坐标

使用方法可见demo目录下的ege_new_drawimage.cpp