### PR TITLE
将 ege::resize 函数的行为改回会填充背景色，并增加不填充背景色的 ege::resize_f 函数

### DIFF
--- a/demo/egedemo.cpp
+++ b/demo/egedemo.cpp
@@ -262,7 +262,6 @@ public:
 \n    }\
 \n    getch();\n    return 0;\n}";
             resize(img, 320, 480);
-            cleardevice(img);
             setfont(12, 0, "宋体", img);
             setbkmode(TRANSPARENT, img);
             setcolor(0x808080, img);
@@ -336,7 +335,6 @@ public:
 \n    }\
 \n    getch();\n    return 0;\n}";
             resize(img, 320, 480);
-            cleardevice(img);
             setfont(12, 0, "宋体", img);
             setbkmode(TRANSPARENT, img);
             setcolor(0x808080, img);
@@ -402,7 +400,6 @@ public:
 \n        }\
 \n    }\n    getch();\n    return 0;\n}";
             resize(img, 320, 480);
-            cleardevice(img);
             setfont(12, 0, "宋体", img);
             setbkmode(TRANSPARENT, img);
             setcolor(0x808080, img);
@@ -501,7 +498,6 @@ public:
 \n        setcolor(HSVtoRGB((float)color, 1.0f, 1.0f));\
 \n        circle(x, 100, 100);\n    }\n    getch();\n    return 0;\n}";
             resize(img, 320, 480);
-            cleardevice(img);
             setfont(12, 0, "宋体", img);
             setbkmode(TRANSPARENT, img);
             setcolor(0x808080, img);
@@ -591,7 +587,6 @@ public:
 \n        setcolor(0xFF0080);\
 \n        circle(x, 100, 100);\n    }\n    getch();\n    return 0;\n}";
             resize(img, 320, 480);
-            cleardevice(img);
             setfont(12, 0, "宋体", img);
             setbkmode(TRANSPARENT, img);
             setcolor(0x808080, img);
@@ -947,7 +942,6 @@ public:
 ";
             m_resettext = 0;
             resize(img, 320, 480);
-            cleardevice(img);
             setfont(12, 0, "宋体", img);
             setbkmode(TRANSPARENT, img);
             setcolor(0x808080, img);
@@ -1024,7 +1018,6 @@ public:
 \n    }\
 \n    getch();\n    return 0;\n}";
             resize(img, 320, 480);
-            cleardevice(img);
             setfont(12, 0, "宋体", img);
             setbkmode(TRANSPARENT, img);
             setcolor(0x808080, img);

--- a/man/api/img/index.htm
+++ b/man/api/img/index.htm
@@ -25,6 +25,7 @@
 <tr><td><a href="putimage_rotatetransparent.htm">putimage_rotatetransparent</a></td><td>将图像旋转缩放后以透明方式绘制</td></tr>
 
 <tr><td><a href="resize.htm">resize</a></td><td>调整图像尺寸</td></tr>
+<tr><td><a href="resize_f.htm">resize_f</a></td><td>调整图像尺寸，不进行背景色填充</td></tr>
 <tr><td><a href="getwidth.htm">getwidth</a></td><td>获取图像宽度</td></tr>
 <tr><td><a href="getheight.htm">getheight</a></td><td>获取图像高度</td></tr>
 <tr><td><a href="getbuffer.htm">getbuffer</a></td><td>获取图像缓存区</td></tr>

--- a/man/api/img/resize_f.htm
+++ b/man/api/img/resize_f.htm
@@ -4,10 +4,10 @@
 </head>
 <body>
 
-<pre><font size="4"><a href="../../index.htm">主页</a>-＞<a href="../index.htm">库函数目录</a>-＞<a href="index.htm">图像处理相关函数</a>-＞resize</font>
+<pre><font size="4"><a href="../../index.htm">主页</a>-＞<a href="../index.htm">库函数目录</a>-＞<a href="index.htm">图像处理相关函数</a>-＞resize_f</font>
 <font size="4">
 <font size="5" color="#0000FF"><strong>功能：</strong></font>
-这个函数用于调整图像的尺寸，调整后，图像用背景色填充，视口还原为初始状态。
+这个函数用于调整图像的尺寸，调整后，图像内容未定义，视口还原为初始状态。
 
 <font size="5" color="#0000FF"><strong>声明：</strong></font>
 <pre><font color=#0000FF>int </font><font color=#008080>resize</font>(

--- a/src/ege.h
+++ b/src/ege.h
@@ -961,7 +961,8 @@ void           EGEAPI delimage(PCIMAGE pImg);          // 删除 PIMAGE
 color_t*       EGEAPI getbuffer(PIMAGE pImg);
 const color_t* EGEAPI getbuffer(PCIMAGE pImg);
 
-int  EGEAPI resize(PIMAGE pDstImg, int width, int height); //重设尺寸
+int  EGEAPI resize_f(PIMAGE pDstImg, int width, int height);  //重设尺寸，但不填充背景色
+int  EGEAPI resize(PIMAGE pDstImg, int width, int height); //重设尺寸，并填充背景色
 int EGEAPI getimage(PIMAGE pDstImg, int srcX, int srcY, int srcWidth, int srcHeight);                             // 从屏幕获取图像
 int EGEAPI getimage(PIMAGE pDstImg, PCIMAGE pSrcImg, int srcX, int srcY, int srcWidth, int srcHeight);            // 从另一个 PIMAGE 对象中获取图像
 int  EGEAPI getimage(PIMAGE pDstImg, LPCSTR  pImgFile, int zoomWidth = 0, int zoomHeight = 0);                     // 从图片文件获取图像(bmp/jpg/gif/emf/wmf)

--- a/src/ege_head.h
+++ b/src/ege_head.h
@@ -299,6 +299,7 @@ public:
 #endif
 	void enable_anti_alias(bool enable);
 
+	int  resize_f(int width, int height);
 	int  resize(int width, int height);
 	void copyimage(PCIMAGE pSrcImg);
 	int getimage(int srcX, int srcY, int srcWidth, int srcHeight);

--- a/src/egegapi.cpp
+++ b/src/egegapi.cpp
@@ -2765,7 +2765,6 @@ inputbox_getline(LPCWSTR title, LPCWSTR text, LPWSTR buf, int len) {
 
 	bg.getimage(0, 0, getwidth(), getheight());
 	window.resize(w, h);
-	cleardevice(&window);
 	buf[0] = 0;
 
 	lock_window = pg->lock_window;

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -303,7 +303,7 @@ int
 IMAGE::getimage(PCIMAGE pSrcImg, int srcX, int srcY, int srcWidth, int srcHeight) {
 	inittest(L"IMAGE::getimage");
 	PCIMAGE img = CONVERT_IMAGE_CONST(pSrcImg);
-	this->resize(srcWidth, srcHeight);
+	this->resize_f(srcWidth, srcHeight);
 	BitBlt(this->m_hDC, 0, 0, srcWidth, srcHeight, img->m_hDC, srcX, srcY, SRCCOPY);
 	CONVERT_IMAGE_END;
 	return grOk;
@@ -369,7 +369,7 @@ inline void getimage_from_IPicture(PIMAGE self, IPicture* pPicture) {
 		::ReleaseDC(NULL, ScreenDC);
 	}
 
-	self->resize(lWidthPixels, lHeightPixels);
+	self->resize_f(lWidthPixels, lHeightPixels);
 	{
 		HDC dc = self->m_hDC;
 
@@ -499,7 +499,7 @@ void getimage_from_png_struct(PIMAGE self, void* vpng_ptr, void* vinfo_ptr) {
 	png_infop info_ptr = (png_infop)vinfo_ptr;
 	png_read_png(png_ptr, info_ptr, PNG_TRANSFORM_BGR|PNG_TRANSFORM_EXPAND, NULL);
 	png_set_expand(png_ptr);
-	self->resize((int)(info_ptr->width), (int)(info_ptr->height)); //png_get_IHDR
+	self->resize_f((int)(info_ptr->width), (int)(info_ptr->height)); //png_get_IHDR
 
 	PDWORD m_pBuffer = self->m_pBuffer;
 	const png_uint_32 width = info_ptr->width;

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -250,9 +250,8 @@ void IMAGE::enable_anti_alias(bool enable){
 #endif
 }
 
-int
-IMAGE::resize(int width, int height) {
-	inittest(L"IMAGE::resize");
+int IMAGE::resize_f(int width, int height) {
+	inittest(L"IMAGE::resize_f");
 
 	// Ωÿ÷πµΩ 0
 	if (width < 0) width = 0;
@@ -276,6 +275,13 @@ IMAGE::resize(int width, int height) {
 	setviewport(0, 0, m_width, m_height, 1, this);
 
 	return 0;
+}
+
+int IMAGE::resize(int width, int height) {
+	inittest(L"IMAGE::resize");
+	int ret = this->resize_f(width, height);
+	cleardevice(this);
+	return ret;
 }
 
 IMAGE&
@@ -2797,9 +2803,11 @@ HDC getHDC(PCIMAGE pImg) {
 	return img->getdc();
 }
 
-int
-resize(PIMAGE pDstImg, int width, int height) {
-	
+int resize_f(PIMAGE pDstImg, int width, int height) {
+	return pDstImg->resize_f(width, height);
+}
+
+int resize(PIMAGE pDstImg, int width, int height) {
 	return pDstImg->resize(width, height);
 }
 


### PR DESCRIPTION
从 #44 可见之前的修改是个错误，他还是个 break change，还很容易被误用，一般以绘图为目的的使用中 resize 后总是要填充背景的。