### PR TITLE
使sys_edit的isfocus()方法可用

### DIFF
--- a/demo/multiplesys_edit.cpp
+++ b/demo/multiplesys_edit.cpp
@@ -1,0 +1,61 @@
+#include <graphics.h>
+#include <stdio.h>
+#include <ege/sys_edit.h>
+
+#define BUFFER_LEN 200
+
+int main()
+{
+	initgraph(640, 480);
+	setbkcolor(WHITE);
+	
+	char buffer[BUFFER_LEN+1];
+
+	sys_edit editBox;
+	editBox.create(false);
+	editBox.size(200, 24 + 8);
+	editBox.setbgcolor(YELLOW);
+	editBox.setfont(24, 0, "黑体");
+	editBox.move(40, 40);
+	editBox.visible(true);
+
+	sys_edit editBox1;
+	editBox1.create(false);
+	editBox1.size(200, 24+8);
+	editBox1.setbgcolor(YELLOW);
+	editBox1.setfont(24, 0, "黑体");
+	editBox1.move(40, 140);
+	editBox1.visible(true);
+
+	editBox.setfocus();
+
+	//处理交互，不可少，否则直接退出
+	key_msg msg;
+	while (is_run()) {
+		msg = getkey();
+		if ((msg.msg == key_msg_down) && (msg.key == key_enter)) {
+			if (editBox.isfocus()) {
+				//跳到下一个输入框
+				editBox1.setfocus();
+			} else if (editBox1.isfocus()) {
+				//结束输入
+				flushkey();
+				break;
+			}
+		}
+	}
+	
+	editBox.gettext(BUFFER_LEN,buffer);
+	
+	xyprintf(40, 80, buffer);
+	
+	editBox1.gettext(BUFFER_LEN,buffer);
+	
+	xyprintf(40, 180, buffer);
+	
+	
+	getch();
+	closegraph();
+
+	return 0;
+}

--- a/src/ege/egecontrolbase.h
+++ b/src/ege/egecontrolbase.h
@@ -171,7 +171,7 @@ private:
 	PIMAGE   m_mainbuf;      // 主缓冲
 	PIMAGE   m_mainFilter;   // 过滤器
 
-private:
+protected:
 	int m_bVisible;     // 是否可见
 	int m_bEnable;      // 是否可获得输入（键盘和鼠标）
 	int m_bAutoDraw;    // 是否自动绘画到窗口上
@@ -183,6 +183,8 @@ private:
 	int m_allocId;      // 分配id
 	int m_allocZorder;  // 分配Z次序
 
+
+private:
 	egeControlBase* m_parent;
 	static int s_maxchildid;   // 下一次子控件分配ID值
 

--- a/src/ege/sys_edit.h
+++ b/src/ege/sys_edit.h
@@ -175,8 +175,7 @@ public:
         msg.hwnd = m_hwnd;
         msg.hEvent = ::CreateEvent(NULL, TRUE, FALSE, NULL);
         ::PostMessageW(getHWnd(), WM_USER + 2, 0, (LPARAM)&msg);
-        ::WaitForSingleObject(msg.hEvent, INFINITE);    	
-        
+        ::WaitForSingleObject(msg.hEvent, INFINITE);
     }
     virtual int  onGetFocus() {
         m_bInputFocus = 1;

--- a/src/ege/sys_edit.h
+++ b/src/ege/sys_edit.h
@@ -179,7 +179,7 @@ public:
         
     }
     virtual int  onGetFocus() {
-    	m_bInputFocus = 1;
+        m_bInputFocus = 1;
         return 0;
     }
     virtual void onLostFocus() {

--- a/src/ege/sys_edit.h
+++ b/src/ege/sys_edit.h
@@ -177,13 +177,6 @@ public:
         ::PostMessageW(getHWnd(), WM_USER + 2, 0, (LPARAM)&msg);
         ::WaitForSingleObject(msg.hEvent, INFINITE);
     }
-    virtual int  onGetFocus() {
-        m_bInputFocus = 1;
-        return 0;
-    }
-    virtual void onLostFocus() {
-        m_bInputFocus = 0;
-    }
 protected:
     HWND        m_hwnd;
     HFONT       m_hFont;

--- a/src/ege/sys_edit.h
+++ b/src/ege/sys_edit.h
@@ -171,7 +171,19 @@ public:
         ::InvalidateRect(m_hwnd, NULL, TRUE);
     }
     void setfocus() {
-        ::PostMessageW(getHWnd(), WM_USER + 2, 0, (LPARAM)m_hwnd);
+        msg_createwindow msg = {NULL};
+        msg.hwnd = m_hwnd;
+        msg.hEvent = ::CreateEvent(NULL, TRUE, FALSE, NULL);
+        ::PostMessageW(getHWnd(), WM_USER + 2, 0, (LPARAM)&msg);
+        ::WaitForSingleObject(msg.hEvent, INFINITE);    	
+        
+    }
+    virtual int  onGetFocus() {
+    	m_bInputFocus = 1;
+        return 0;
+    }
+    virtual void onLostFocus() {
+        m_bInputFocus = 0;
     }
 protected:
     HWND        m_hwnd;

--- a/src/egegapi.cpp
+++ b/src/egegapi.cpp
@@ -2937,23 +2937,30 @@ ege_uncompress(void *dest, unsigned long *destLen, const void *source, unsigned 
 }
 
 LRESULT sys_edit::onMessage(UINT message, WPARAM wParam, LPARAM lParam) {
-	if (message == WM_CTLCOLOREDIT) {
-		HDC dc = (HDC)wParam;
-		HBRUSH br = ::CreateSolidBrush(ARGBTOZBGR(m_bgcolor));
-
-		::SetBkColor(dc, ARGBTOZBGR(m_bgcolor));
-		::SetTextColor(dc, ARGBTOZBGR(m_color));
-		::DeleteObject(m_hBrush);
-		m_hBrush = br;
-		return (LRESULT)br;
-	//} else if (message == WM_SETFOCUS) {
-	//    int a = 0;
-	//    int b = 1;
-	//    return 0;
-	} else {
-		return ((LRESULT (CALLBACK *)(HWND, UINT, WPARAM, LPARAM))m_callback)(m_hwnd, message, wParam, lParam);
+	switch(message) {
+		case WM_CTLCOLOREDIT: 
+			{
+				HDC dc = (HDC)wParam;
+				HBRUSH br = ::CreateSolidBrush(ARGBTOZBGR(m_bgcolor));
+	
+				::SetBkColor(dc, ARGBTOZBGR(m_bgcolor));
+				::SetTextColor(dc, ARGBTOZBGR(m_color));
+				::DeleteObject(m_hBrush);
+				m_hBrush = br;
+				return (LRESULT)br;			
+			}
+			break;
+		case WM_SETFOCUS:
+			m_bInputFocus = 1;
+			// call textbox's own message process to show caret
+			return ((LRESULT (CALLBACK *)(HWND, UINT, WPARAM, LPARAM))m_callback)(m_hwnd, message, wParam, lParam);		
+		case WM_KILLFOCUS:
+			m_bInputFocus = 0;
+			// call textbox's own message process to hide caret
+			return ((LRESULT (CALLBACK *)(HWND, UINT, WPARAM, LPARAM))m_callback)(m_hwnd, message, wParam, lParam);
+		default:
+			return ((LRESULT (CALLBACK *)(HWND, UINT, WPARAM, LPARAM))m_callback)(m_hwnd, message, wParam, lParam);
 	}
-	//return 0;
 }
 
 } // namespace ege

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -1076,8 +1076,7 @@ wndproc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam) {
 			((egeControlBase*)pg_w)->onLostFocus();
 			return 0;
 		}
-		break;		
-		
+		break;			
 	default:
 		if (pg != pg_w) {
 			return ((egeControlBase*)pg_w)->onMessage(message, wParam, lParam);

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -1053,8 +1053,12 @@ wndproc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam) {
 	case WM_USER + 1:
 		windowmanager(pg, (wParam != 0), (struct msg_createwindow*)lParam);
 		break;
-	case WM_USER + 2:
-		::SetFocus((HWND)lParam);
+	case WM_USER + 2: 
+		{
+			struct msg_createwindow* msg = (struct msg_createwindow*)lParam;
+			::SetFocus(msg->hwnd);
+			::SetEvent(msg->hEvent);
+		}
 		break;
 	case WM_CTLCOLOREDIT:
 		{
@@ -1062,6 +1066,18 @@ wndproc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam) {
 			return ctl->onMessage(message, wParam, lParam);
 		}
 		break;
+	case WM_SETFOCUS:
+		if (pg != pg_w) {
+			return ((egeControlBase*)pg_w)->onGetFocus();
+		}
+		break;		
+	case WM_KILLFOCUS:
+		if (pg != pg_w) {
+			((egeControlBase*)pg_w)->onLostFocus();
+			return 0;
+		}
+		break;		
+		
 	default:
 		if (pg != pg_w) {
 			return ((egeControlBase*)pg_w)->onMessage(message, wParam, lParam);

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -1066,17 +1066,6 @@ wndproc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam) {
 			return ctl->onMessage(message, wParam, lParam);
 		}
 		break;
-	case WM_SETFOCUS:
-		if (pg != pg_w) {
-			return ((egeControlBase*)pg_w)->onGetFocus();
-		}
-		break;		
-	case WM_KILLFOCUS:
-		if (pg != pg_w) {
-			((egeControlBase*)pg_w)->onLostFocus();
-			return 0;
-		}
-		break;			
 	default:
 		if (pg != pg_w) {
 			return ((egeControlBase*)pg_w)->onMessage(message, wParam, lParam);


### PR DESCRIPTION
之前sys_edit继承自egeBaseControl的isfocus()方法并没有真正实现，程序无法用它来判断某控件是否获得了焦点
本次修改 使其真正可用