### PR TITLE
fix: 修复 color_t 和 EGE 颜色宏引起的编译错误

### DIFF
--- a/demo/egesnake.cpp
+++ b/demo/egesnake.cpp
@@ -4,7 +4,7 @@
 
 #define MAP_W 40
 #define MAP_H 30
-const int GCOLOR[] = {DARKGRAY, GREEN, RED};
+const color_t GCOLOR[] = {DARKGRAY, GREEN, RED};
 
 int gw, gh;
 

--- a/src/ege.h
+++ b/src/ege.h
@@ -145,10 +145,10 @@
 #define EGE_GDIPLUS     //启用GDIPLUS
 
 #define SHOWCONSOLE             1       // 进入图形模式时，保留控制台的显示
-#define EGERGBA(r, g, b, a)     (color_t)( ((r)<<16) | ((g)<<8) | (b) | ((a)<<24) )
+#define EGERGBA(r, g, b, a)     ((::ege::color_t)( ((r)<<16) | ((g)<<8) | (b) | ((a)<<24) ))
 #define EGERGB(r, g, b)         EGERGBA(r, g, b, 0xFF)
 #define EGEARGB(a, r, g, b)     EGERGBA(r, g, b, a)
-#define EGEACOLOR(a, color)     (color_t)( ((color) & 0xFFFFFF) | ((a)<<24) )
+#define EGEACOLOR(a, color)     ((::ege::color_t)( ((color) & 0xFFFFFF) | ((a)<<24) ))
 #define EGECOLORA(color, a)     EGEACOLOR(a, color)
 #define EGEGET_R(c)             ( ((c)>>16) & 0xFF )
 #define EGEGET_G(c)             ( ((c)>> 8) & 0xFF )


### PR DESCRIPTION
在颜色宏中使用完整路径 ::ege::color_t 进行强转。