### PR TITLE
fix: 删除主测试代码中的 scanf 调用

### DIFF
--- a/src/graphicstest/maintest.cpp
+++ b/src/graphicstest/maintest.cpp
@@ -128,7 +128,6 @@ int main()
     Window2 w[3];
     //fps f;
     sys_edit edit;
-    scanf("%*s");
     edit.create();
     edit.size(100, 18);
     edit.visible(true);


### PR DESCRIPTION
这句 `scanf("%*s")` 从一开始就存在，不知道有啥用。

删掉之后就能修复 #74 。