### PR TITLE
对支持C++ 11或以上标准的编译器，增加颜色相关的constexpr函数。同时保留相关宏定义以兼容旧版本

### DIFF
--- a/demo/ege5star.cpp
+++ b/demo/ege5star.cpp
@@ -27,10 +27,9 @@ int main()
         if (r > PI * 2) r -= PI * 2;
 
         cleardevice();
-        setcolor( RGB(0xff, 0xff, 0xff) );
-        setfillcolor( RGB(0, 0, 0xff) );
+        setcolor( EGERGB(0xff, 0xff, 0xff) );
+        setfillcolor( EGERGB(0xff,0,0) );
         paintstar(300, 200, 100, r);
     }
     return 0;
 }
-

--- a/demo/egeclock.cpp
+++ b/demo/egeclock.cpp
@@ -25,8 +25,8 @@ void draw()
     ege::setbkmode(TRANSPARENT);
 
     ege::ege_enable_aa(true);
-    ege::setfillcolor(EGEARGB(0xff, 0x40, 0x40, 0x40));
-    ege::setcolor(EGEARGB(0xff, 0x80, 0x00, 0xf0));
+    ege::setfillcolor(ege::EGEARGB(0xff, 0x40, 0x40, 0x40));
+    ege::setcolor(ege::EGEARGB(0xff, 0x80, 0x00, 0xf0));
     ege::ege_fillellipse(center.x - r * 1.2f, center.y - r * 1.2f,
             r * 1.2f * 2.0f, r * 1.2f * 2.0f);
 
@@ -41,7 +41,7 @@ void draw()
     time_t t_now;
     time(&t_now);
     tm* t = localtime(&t_now);
-    ege::setcolor(EGEARGB(0xff, 0x0, 0x0, 0xff));
+    ege::setcolor(ege::EGEARGB(0xff, 0x0, 0x0, 0xff));
     ege::setlinewidth(10.0f);
     {
         float h = float(t->tm_hour + t->tm_min / 60.0);
@@ -49,7 +49,7 @@ void draw()
         ege::ege_point p = getpos(center, float(h * pi2 / 12), r * 0.5f);
         ege::ege_line(p.x, p.y, center.x, center.y);
     }
-    ege::setcolor(EGEARGB(0xff, 0xff, 0x0, 0xff));
+    ege::setcolor(ege::EGEARGB(0xff, 0xff, 0x0, 0xff));
     ege::setlinewidth(5.0f);
     {
         float m = float(t->tm_min + t->tm_sec / 60.0);
@@ -57,8 +57,8 @@ void draw()
         ege::ege_point p = getpos(center, float(m * pi2 / 60), r * 0.9f);
         ege::ege_line(p.x, p.y, center.x, center.y);
     }
-    ege::setcolor(EGEARGB(0xff, 0xff, 0xff, 0));
-    ege::setfillcolor(EGEARGB(0xff, 0xff, 0xff, 0));
+    ege::setcolor(ege::EGEARGB(0xff, 0xff, 0xff, 0));
+    ege::setfillcolor(ege::EGEARGB(0xff, 0xff, 0xff, 0));
     ege::setlinewidth(1.0f);
     {
         float s = float(t->tm_sec);
@@ -73,7 +73,7 @@ void draw()
         sprintf(str, "%d/%02d/%02d %2d:%02d:%02d",
                 t->tm_year + 1900, t->tm_mon + 1, t->tm_mday,
                 t->tm_hour, t->tm_min, t->tm_sec);
-        ege::setcolor(EGERGB(0xff, 0xff, 0));
+        ege::setcolor(ege::EGERGB(0xff, 0xff, 0));
         ege::outtextxy((int)center.x, (int)(center.y + r * 1.4f), str);
     }
 }

--- a/demo/egeclock.cpp
+++ b/demo/egeclock.cpp
@@ -25,8 +25,8 @@ void draw()
     ege::setbkmode(TRANSPARENT);
 
     ege::ege_enable_aa(true);
-    ege::setfillcolor(ege::EGEARGB(0xff, 0x40, 0x40, 0x40));
-    ege::setcolor(ege::EGEARGB(0xff, 0x80, 0x00, 0xf0));
+    ege::setfillcolor(EGEARGB(0xff, 0x40, 0x40, 0x40));
+    ege::setcolor(EGEARGB(0xff, 0x80, 0x00, 0xf0));
     ege::ege_fillellipse(center.x - r * 1.2f, center.y - r * 1.2f,
             r * 1.2f * 2.0f, r * 1.2f * 2.0f);
 
@@ -41,7 +41,7 @@ void draw()
     time_t t_now;
     time(&t_now);
     tm* t = localtime(&t_now);
-    ege::setcolor(ege::EGEARGB(0xff, 0x0, 0x0, 0xff));
+    ege::setcolor(EGEARGB(0xff, 0x0, 0x0, 0xff));
     ege::setlinewidth(10.0f);
     {
         float h = float(t->tm_hour + t->tm_min / 60.0);
@@ -49,7 +49,7 @@ void draw()
         ege::ege_point p = getpos(center, float(h * pi2 / 12), r * 0.5f);
         ege::ege_line(p.x, p.y, center.x, center.y);
     }
-    ege::setcolor(ege::EGEARGB(0xff, 0xff, 0x0, 0xff));
+    ege::setcolor(EGEARGB(0xff, 0xff, 0x0, 0xff));
     ege::setlinewidth(5.0f);
     {
         float m = float(t->tm_min + t->tm_sec / 60.0);
@@ -57,8 +57,8 @@ void draw()
         ege::ege_point p = getpos(center, float(m * pi2 / 60), r * 0.9f);
         ege::ege_line(p.x, p.y, center.x, center.y);
     }
-    ege::setcolor(ege::EGEARGB(0xff, 0xff, 0xff, 0));
-    ege::setfillcolor(ege::EGEARGB(0xff, 0xff, 0xff, 0));
+    ege::setcolor(EGEARGB(0xff, 0xff, 0xff, 0));
+    ege::setfillcolor(EGEARGB(0xff, 0xff, 0xff, 0));
     ege::setlinewidth(1.0f);
     {
         float s = float(t->tm_sec);
@@ -73,7 +73,7 @@ void draw()
         sprintf(str, "%d/%02d/%02d %2d:%02d:%02d",
                 t->tm_year + 1900, t->tm_mon + 1, t->tm_mday,
                 t->tm_hour, t->tm_min, t->tm_sec);
-        ege::setcolor(ege::EGERGB(0xff, 0xff, 0));
+        ege::setcolor(EGERGB(0xff, 0xff, 0));
         ege::outtextxy((int)center.x, (int)(center.y + r * 1.4f), str);
     }
 }
@@ -99,5 +99,4 @@ int main()
     ege::closegraph();
     return 0;
 }
-
 

--- a/src/ege.h
+++ b/src/ege.h
@@ -157,7 +157,7 @@
 #define EGEGRAY(gray)           EGERGB(gray, gray, gray)
 #define EGEGRAYA(gray, a)       EGERGBA(gray, gray, gray, a)
 #define EGEAGRAY(a, gray)       EGEGRAYA(gray, a)
-#//#define NAMESPACE_EGE_L         namespace ege {
+//#define NAMESPACE_EGE_L         namespace ege {
 //#define NAMESPACE_EGE_R         }
 
 namespace ege {

--- a/src/ege.h
+++ b/src/ege.h
@@ -145,6 +145,8 @@
 #define EGE_GDIPLUS     //启用GDIPLUS
 
 #define SHOWCONSOLE             1       // 进入图形模式时，保留控制台的显示
+// 当使用的编译器不支持C++11时，使用宏定义
+#if __cplusplus < 201103L
 #define EGERGBA(r, g, b, a)     ((::ege::color_t)( ((r)<<16) | ((g)<<8) | (b) | ((a)<<24) ))
 #define EGERGB(r, g, b)         EGERGBA(r, g, b, 0xFF)
 #define EGEARGB(a, r, g, b)     EGERGBA(r, g, b, a)
@@ -157,6 +159,7 @@
 #define EGEGRAY(gray)           EGERGB(gray, gray, gray)
 #define EGEGRAYA(gray, a)       EGERGBA(gray, gray, gray, a)
 #define EGEAGRAY(a, gray)       EGEGRAYA(gray, a)
+#endif
 //#define NAMESPACE_EGE_L         namespace ege {
 //#define NAMESPACE_EGE_R         }
 
@@ -246,6 +249,23 @@ enum message_mouse {
 };
 
 typedef DWORD color_t;
+
+//对于支持C++11 constexpr的编译器，使用内联函数定义
+#if __cplusplus >= 201103L
+constexpr color_t EGERGBA(int r, int g, int b, int a) { return ( ((r & 0xFF)<<16) | ((g & 0xFF)<<8) | (b & 0xFF) | ((a & 0xFF)<<24) ); }
+constexpr color_t EGERGB(int r, int g, int b) { return EGERGBA(r, g, b, 0xFF); }
+constexpr color_t EGEARGB(int a, int r, int g, int b) { return EGERGBA(r, g, b, a); }
+constexpr color_t EGEACOLOR(int  a, color_t color) { return ( ((color) & 0xFFFFFF) | ((a & 0xFF)<<24) ); }
+constexpr color_t EGECOLORA(color_t color, int  a)  { return EGEACOLOR(a, color); }
+constexpr unsigned char EGEGET_R(color_t c) { return ( ((c)>>16) & 0xFF ); }
+constexpr unsigned char EGEGET_G(color_t c) { return ( ((c)>> 8) & 0xFF ); }
+constexpr unsigned char EGEGET_B(color_t c) { return ( ((c)) & 0xFF ); }
+constexpr unsigned char EGEGET_A(color_t c) { return ( ((c)>>24) & 0xFF); }
+constexpr color_t EGEGRAY(int gray) { return EGERGB(gray, gray, gray); }
+constexpr color_t EGEGRAYA(int gray, int  a) { return EGERGBA(gray, gray, gray, a); }
+constexpr color_t EGEAGRAY(int a, int gray) { return EGEGRAYA(gray, a); }
+#endif
+
 // 颜色
 enum COLORS {
 	ALICEBLUE              = EGERGB(0xF0, 0xF8, 0xFF),

--- a/src/ege.h
+++ b/src/ege.h
@@ -145,6 +145,20 @@
 #define EGE_GDIPLUS     //ÆôÓÃGDIPLUS
 
 #define SHOWCONSOLE             1       // ½øÈëÍ¼ÐÎÄ£Ê½Ê±£¬±£Áô¿ØÖÆÌ¨µÄÏÔÊ¾
+#if __cplusplus >= 201103L
+#define EGERGBA 				::ege::rgba
+#define EGERGB					::ege::rgb
+#define EGEARGB					::ege::argb
+#define EGEACOLOR				::ege::acolor
+#define EGECOLORA				::ege::colora
+#define EGEGET_R				::ege::get_r
+#define EGEGET_G             	::ege::get_g
+#define EGEGET_B				::ege::get_b
+#define EGEGET_A				::ege::get_a
+#define EGEGRAY					::ege::gray
+#define EGEGRAYA				::ege::graya
+#define EGEAGRAY				::ege::agray
+#else
 #define EGERGBA(r, g, b, a)     ((::ege::color_t)( ((r)<<16) | ((g)<<8) | (b) | ((a)<<24) ))
 #define EGERGB(r, g, b)         EGERGBA(r, g, b, 0xFF)
 #define EGEARGB(a, r, g, b)     EGERGBA(r, g, b, a)
@@ -157,6 +171,8 @@
 #define EGEGRAY(gray)           EGERGB(gray, gray, gray)
 #define EGEGRAYA(gray, a)       EGERGBA(gray, gray, gray, a)
 #define EGEAGRAY(a, gray)       EGEGRAYA(gray, a)
+#endif
+
 //#define NAMESPACE_EGE_L         namespace ege {
 //#define NAMESPACE_EGE_R         }
 
@@ -864,11 +880,11 @@ void EGEAPI setfontbkcolor(color_t color, PIMAGE pimg = NULL);  // ÉèÖÃµ±Ç°ÎÄ×Ö±
 void EGEAPI setbkmode(int iBkMode, PIMAGE pimg = NULL);         // ÉèÖÃ±³¾°»ìºÏÄ£Ê½(0=OPAQUE, 1=TRANSPARENT)
 
 // ¼æÈÝºê
-#define RGBtoGRAY   rgb2gray
-#define RGBtoHSL    rgb2hsl
-#define RGBtoHSV    rgb2hsv
-#define HSLtoRGB    hsl2rgb
-#define HSVtoRGB    hsv2rgb
+#define RGBtoGRAY   ::ege::rgb2gray
+#define RGBtoHSL    ::ege::rgb2hsl
+#define RGBtoHSV    ::ege::rgb2hsv
+#define HSLtoRGB    ::ege::hsl2rgb
+#define HSVtoRGB    ::ege::hsv2rgb
 
 // ÑÕÉ«Ä£ÐÍ×ª»»º¯Êý
 color_t     EGEAPI rgb2gray(color_t rgb);

--- a/src/ege.h
+++ b/src/ege.h
@@ -145,8 +145,6 @@
 #define EGE_GDIPLUS     //启用GDIPLUS
 
 #define SHOWCONSOLE             1       // 进入图形模式时，保留控制台的显示
-// 当使用的编译器不支持C++11时，使用宏定义
-#if __cplusplus < 201103L
 #define EGERGBA(r, g, b, a)     ((::ege::color_t)( ((r)<<16) | ((g)<<8) | (b) | ((a)<<24) ))
 #define EGERGB(r, g, b)         EGERGBA(r, g, b, 0xFF)
 #define EGEARGB(a, r, g, b)     EGERGBA(r, g, b, a)
@@ -159,8 +157,7 @@
 #define EGEGRAY(gray)           EGERGB(gray, gray, gray)
 #define EGEGRAYA(gray, a)       EGERGBA(gray, gray, gray, a)
 #define EGEAGRAY(a, gray)       EGEGRAYA(gray, a)
-#endif
-//#define NAMESPACE_EGE_L         namespace ege {
+#//#define NAMESPACE_EGE_L         namespace ege {
 //#define NAMESPACE_EGE_R         }
 
 namespace ege {
@@ -250,20 +247,20 @@ enum message_mouse {
 
 typedef DWORD color_t;
 
-//对于支持C++11 constexpr的编译器，使用内联函数定义
+//对于支持C++11 constexpr的编译器，定义相关颜色函数
 #if __cplusplus >= 201103L
-constexpr color_t EGERGBA(int r, int g, int b, int a) { return ( ((r & 0xFF)<<16) | ((g & 0xFF)<<8) | (b & 0xFF) | ((a & 0xFF)<<24) ); }
-constexpr color_t EGERGB(int r, int g, int b) { return EGERGBA(r, g, b, 0xFF); }
-constexpr color_t EGEARGB(int a, int r, int g, int b) { return EGERGBA(r, g, b, a); }
-constexpr color_t EGEACOLOR(int  a, color_t color) { return ( ((color) & 0xFFFFFF) | ((a & 0xFF)<<24) ); }
-constexpr color_t EGECOLORA(color_t color, int  a)  { return EGEACOLOR(a, color); }
-constexpr unsigned char EGEGET_R(color_t c) { return ( ((c)>>16) & 0xFF ); }
-constexpr unsigned char EGEGET_G(color_t c) { return ( ((c)>> 8) & 0xFF ); }
-constexpr unsigned char EGEGET_B(color_t c) { return ( ((c)) & 0xFF ); }
-constexpr unsigned char EGEGET_A(color_t c) { return ( ((c)>>24) & 0xFF); }
-constexpr color_t EGEGRAY(int gray) { return EGERGB(gray, gray, gray); }
-constexpr color_t EGEGRAYA(int gray, int  a) { return EGERGBA(gray, gray, gray, a); }
-constexpr color_t EGEAGRAY(int a, int gray) { return EGEGRAYA(gray, a); }
+constexpr color_t rgba(int r, int g, int b, int a) { return ( ((r & 0xFF)<<16) | ((g & 0xFF)<<8) | (b & 0xFF) | ((a & 0xFF)<<24) ); }
+constexpr color_t rgb(int r, int g, int b) { return rgba(r, g, b, 0xFF); }
+constexpr color_t argb(int a, int r, int g, int b) { return rgba(r, g, b, a); }
+constexpr color_t acolor(int  a, color_t color) { return ( ((color) & 0xFFFFFF) | ((a & 0xFF)<<24) ); }
+constexpr color_t colora(color_t color, int  a)  { return acolor(a, color); }
+constexpr unsigned char get_r(color_t c) { return ( ((c)>>16) & 0xFF ); }
+constexpr unsigned char get_g(color_t c) { return ( ((c)>> 8) & 0xFF ); }
+constexpr unsigned char get_b(color_t c) { return ( ((c)) & 0xFF ); }
+constexpr unsigned char get_a(color_t c) { return ( ((c)>>24) & 0xFF); }
+constexpr color_t gray(int gray) { return rgb(gray, gray, gray); }
+constexpr color_t graya(int gray, int  a) { return rgba(gray, gray, gray, a); }
+constexpr color_t agray(int a, int gray) { return graya(gray, a); }
 #endif
 
 // 颜色

--- a/src/ege.h
+++ b/src/ege.h
@@ -146,18 +146,18 @@
 
 #define SHOWCONSOLE             1       // 进入图形模式时，保留控制台的显示
 #if __cplusplus >= 201103L
-#define EGERGBA 				::ege::rgba
-#define EGERGB					::ege::rgb
-#define EGEARGB					::ege::argb
-#define EGEACOLOR				::ege::acolor
-#define EGECOLORA				::ege::colora
-#define EGEGET_R				::ege::get_r
-#define EGEGET_G             	::ege::get_g
-#define EGEGET_B				::ege::get_b
-#define EGEGET_A				::ege::get_a
-#define EGEGRAY					::ege::gray
-#define EGEGRAYA				::ege::graya
-#define EGEAGRAY				::ege::agray
+#define EGERGBA                 ::ege::rgba
+#define EGERGB                  ::ege::rgb
+#define EGEARGB                 ::ege::argb
+#define EGEACOLOR               ::ege::acolor
+#define EGECOLORA               ::ege::colora
+#define EGEGET_R                ::ege::get_r
+#define EGEGET_G                ::ege::get_g
+#define EGEGET_B                ::ege::get_b
+#define EGEGET_A                ::ege::get_a
+#define EGEGRAY                 ::ege::gray
+#define EGEGRAYA                ::ege::graya
+#define EGEAGRAY                ::ege::agray
 #else
 #define EGERGBA(r, g, b, a)     ((::ege::color_t)( ((r)<<16) | ((g)<<8) | (b) | ((a)<<24) ))
 #define EGERGB(r, g, b)         EGERGBA(r, g, b, 0xFF)


### PR DESCRIPTION
constexpr函数既能和宏定义一样，在编译时直接求值，也能提供更好的编译器检查。
是否考虑以后逐渐用它替代宏定义
