### PR TITLE
fix:标记按键按下时第一次发送的down消息

### DIFF
--- a/src/ege.h
+++ b/src/ege.h
@@ -601,8 +601,9 @@ typedef enum key_msg_e {
 	key_msg_char    = 4,
 }key_msg_e;
 typedef enum key_flag_e {
-	key_flag_shift  = 0x100,
-	key_flag_ctrl   = 0x200,
+	key_flag_shift      = 0x100,
+	key_flag_ctrl       = 0x200,
+	key_flag_first_down = 0x80000,
 }key_flag_e;
 
 typedef enum mouse_msg_e {

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -400,6 +400,7 @@ getkey() {
 				else if (key & KEYMSG_CHAR)
 					msg.msg = key_msg_char;
 				msg.key = key & 0xFFFF;
+				if (key & KEYMSG_FIRSTDOWN) msg.flags |= key_flag_first_down;
 				if (keystate(VK_CONTROL)) msg.flags |= key_flag_ctrl;
 				if (keystate(VK_SHIFT)) msg.flags |= key_flag_shift;
 				return msg;


### PR DESCRIPTION
这个属于之前遗漏的标志位，_getkey()返回的值中，已经用 KEYMSG_FIRSTDOWN 标志位标记按键按下时第一次发送的down类型消息，但是在getkey()中没有将这个标志位提取到key_msg结构体的flags成员中。