### PR TITLE
提高sleep精度到2ms左右

### DIFF
--- a/src/egegapi.cpp
+++ b/src/egegapi.cpp
@@ -308,8 +308,11 @@ void movewindow(int x, int y, bool redraw) {
 
 void
 api_sleep(long dwMilliseconds) {
-	if (dwMilliseconds >= 0)
+	if (dwMilliseconds >= 0) {
+		::timeBeginPeriod(1);
 		::Sleep(dwMilliseconds);
+		::timeEndPeriod(1);
+	}
 }
 
 void
@@ -332,6 +335,8 @@ ege_sleep(long ms) {
 	} else if (1) { //高精模式，占CPU更高
 		static HANDLE hTimer = ::CreateWaitableTimer(NULL, TRUE, NULL);
 		LARGE_INTEGER liDueTime;
+		
+		::timeBeginPeriod(1);
 		liDueTime.QuadPart = ms * (LONGLONG)-10000;
 
 		if (hTimer) {
@@ -342,6 +347,7 @@ ege_sleep(long ms) {
 		} else {
 			::Sleep(ms);
 		}
+		::timeEndPeriod(1);
 	}
 }
 

--- a/src/graphicstest/maintest.cpp
+++ b/src/graphicstest/maintest.cpp
@@ -131,7 +131,7 @@ int main()
     edit.create();
     edit.size(100, 18);
     edit.visible(true);
-    for ( ; kbhit() != -1; delay_fps(60)) {
+    for ( ; kbhit() != -1; delay_fps(120)) {
         //f.zorderup();
         {
             char str[20];


### PR DESCRIPTION
在调用sleep前调用timeBeginPeriod()，将windows缺省时间片长度降低到1ms，从而提高sleep的精度。