### PR TITLE
fix:修复程序运行后图形窗口无法激活获得焦点的问题

### DIFF
--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -691,6 +691,7 @@ init_instance(HINSTANCE hInstance) {
 		//DeleteObject(hfont);
 	} //*/
 
+	SetActiveWindow(pg->hwnd);
 
 	pg->exit_window = 0;	
 	return TRUE;
@@ -1284,7 +1285,10 @@ initgraph(int *gdriver, int *gmode, const char *path) {
 
 	UpdateWindow(pg->hwnd);
 
-	ShowWindow(pg->hwnd, SW_SHOW);
+	ShowWindow(pg->hwnd, SW_SHOWNORMAL);
+	BringWindowToTop(pg->hwnd);
+	SetForegroundWindow(pg->hwnd);
+
 	if (g_windowexstyle & WS_EX_TOPMOST) {
 		SetWindowPos(pg->hwnd, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOSIZE | SWP_NOMOVE);
 	}


### PR DESCRIPTION
bug 在 e66176 提交中引入：将 ShowWindow() 从 创建窗口的线程移动到了主线程，而在主线程中调用ShowWindow()只能显示窗口而无法使其激活并获得焦点。