### PR TITLE
修正：未设置gdi+ graphics对象的文字反锯齿属性

### DIFF
--- a/src/image.cpp
+++ b/src/image.cpp
@@ -246,6 +246,7 @@ void IMAGE::enable_anti_alias(bool enable){
 #ifdef EGE_GDIPLUS
 	if (NULL != m_graphics) {
 		m_graphics->SetSmoothingMode(m_aa? Gdiplus::SmoothingModeAntiAlias : Gdiplus::SmoothingModeNone);
+		m_graphics->SetTextRenderingHint(m_aa? Gdiplus::TextRenderingHintAntiAlias : Gdiplus::TextRenderingHintSystemDefault );
 	}
 #endif
 }

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -216,6 +216,7 @@ Gdiplus::Graphics*  IMAGE::getGraphics() {
 		m_graphics=new Gdiplus::Graphics(m_hDC);
 		m_graphics->SetPixelOffsetMode(Gdiplus::PixelOffsetModeHalf);
 		m_graphics->SetSmoothingMode(m_aa? Gdiplus::SmoothingModeAntiAlias : Gdiplus::SmoothingModeNone);
+		m_graphics->SetTextRenderingHint(m_aa? Gdiplus::TextRenderingHintAntiAlias: Gdiplus::TextRenderingHintSystemDefault);
 	}
 	return m_graphics;
 }


### PR DESCRIPTION
在Image对象中缓存了gdi+ graphics对象。
在处理Image对象的enable_aa属性时，只更新了graphics对象的图形反锯齿，未正确设置和更新graphics对象的文字反锯齿。