### PR TITLE
修复 delay_ms(0) 延时过高的问题

### DIFF
--- a/src/egegapi.cpp
+++ b/src/egegapi.cpp
@@ -363,15 +363,10 @@ delay_ms(long ms) {
 	pg->skip_timer_mark = true;
 	if (ms == 0) {
 		if (pg->update_mark_count < UPDATE_MAX_CALL) {
-			ege_sleep(1);
 			root->draw(NULL);
 			dealmessage(pg, FORCE_UPDATE);
 			root->update();
-			{
-				int l,t,r,b,c;
-				getviewport(&l, &t, &r, &b, &c);
-				setviewport(l, t, r, b, c);
-			}
+			ege_sleep(0);
 		}
 		pg->delay_ms_dwLast = get_highfeq_time_ls(pg) * 1000.0;
 		pg->skip_timer_mark = false;
@@ -393,7 +388,6 @@ delay_ms(long ms) {
 			dw = pg->delay_ms_dwLast;
 		}
 
-		//ege_sleep(1);
 		root->draw(NULL);
 		while (dw + delay_time >= get_highfeq_time_ls(pg) * 1000.0) {
 			if ( f <= 0 || pg->update_mark_count < UPDATE_MAX_CALL) {


### PR DESCRIPTION
造成 delay_ms(0) 较高延时的两个因素：

- delay_ms(0) 里加入了一个固定延时 ege_sleep(1)，这个延时在默认设置下通常是 15 到 17ms (EGE 使用了 timePriodBegin(1) 将定时器周期设置为 1 ms，所以额外延时是 1 到 2 ms) 。
- 代码里加了个 setviewport() 设置视口区域，但视口区域并没有做任何修改，应该是多余的，并且对帧率有不小的影响。刷新时不应该改变视口区域。

现在将 ege_sleep(1) 改为 ege_sleep(0)，Sleep() 函数在微软文档里的描述是 "如果值为0，则线程会将其时间片的剩余部分放弃给已准备好运行的任何其他线程。 如果没有其他线程可供运行，函数将立即返回，并且线程继续执行。"