### PR TITLE
Fix: 修复读取 RGB 格式图像后透明通道为 0 的问题

### DIFF
--- a/include/ege.h
+++ b/include/ege.h
@@ -223,6 +223,7 @@ enum graphics_errors
     grInvalidFont        = -13,
     grInvalidFontNum     = -14,
     grInvalidVersion     = -18,
+
     grException          = 0x10, /* ege error */
     grParamError         = 0x11,
     grInvalidRegion      = 0x12,

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -527,7 +527,7 @@ void getimage_from_png_struct(PIMAGE self, void* vpng_ptr, void* vinfo_ptr)
     if (color_type == PNG_COLOR_TYPE_RGB) {
         for (uint32 i = 0; i < height; ++i) {
             for (uint32 j = 0; j < width; ++j) {
-                m_pBuffer[i * width + j] = 0xFFFFFF & (DWORD&)row_pointers[i][j * 3];
+                m_pBuffer[i * width + j] = EGEACOLOR(0xFF, (DWORD&)row_pointers[i][j * 3]);
             }
         }
     } else if (color_type == PNG_COLOR_TYPE_RGBA) {

--- a/src/image.h
+++ b/src/image.h
@@ -213,4 +213,6 @@ public:
     friend void getimage_from_png_struct(PIMAGE, void*, void*);
 };
 
+int getimage_from_bitmap(PIMAGE pimg, Gdiplus::Bitmap& bitmap);
+
 } // namespace ege


### PR DESCRIPTION
**问题**
像素颜色格式为 RGB 的图像，读取后透明通道为 0，这和 ege 中的 RGB 颜色 alpha = 0xFF 的颜色表示不符，导致 putimage_withalpha() 无法绘制出图像。

EGE 中的像素颜色格式为 ARGB, 对于不含透明通道的图像，加载后 Alpha 应以 0xFF 填充。


**实现**

ege 中非 PNG 图片使用 OleLoadPicture() 接口加载，然后从 IPicture 对象中解析出图像数据，但这个 IPicture 无法判断图像是否具有透明通道，因此非 PNG 图像改为使用 GDI+ Bitmap 实现图像读取。


PNG 格式：(由 libpng 读取)

- 额外增加 16 位深度(每通道)格式的判断，将其转换成 8 位深度。
- 读取前传入缓存区地址，避免额外复制操作。
- RGB 格式则添加 alpha 通道，以 `0xFF` 填充

非 PNG 格式：

- 参考 MFC 源码中的 CImage::CreateFromGdiplusBitmap() 实现，将原来 OleLoadPicture() 接口改为使用 GDI+ Bitmap 读取。
- 将像素颜色格式转换为 32 位 ARGB (RGB 格式转换成 ARGB 后 alpha 为 `0xFF` )
- **读取时会有一次将图像数据从 Bitmap 复制到 PIMAGE 图像缓冲区的过程，目前没找到可以直接移交图像数据而避免复制的方法**

**性能**
本地测试读取速度有 4~10 倍提升，可能是原来的接口解析速度太慢。