### PR TITLE
Fix: 修复 RGB32 格式图像读取后预留通道被填充成 0xFF 的问题

### DIFF
--- a/include/ege.h
+++ b/include/ege.h
@@ -824,10 +824,10 @@ class IMAGE;
 typedef IMAGE *PIMAGE;
 typedef const IMAGE *PCIMAGE;
 
-// `codepage` sholde be `EGE_CODEPAGE_XXX`, default is `EGE_CODEPAGE_ANSI`.
+// `codepage` should be `EGE_CODEPAGE_XXX`, default is `EGE_CODEPAGE_ANSI`.
 void EGEAPI setcodepage(unsigned int codepage);
 unsigned int EGEAPI getcodepage();
-// set whether char message of `getkey()` use UTF-16 
+// set whether char message of `getkey()` use UTF-16
 void EGEAPI setunicodecharmessage(bool enable);
 bool EGEAPI getunicodecharmessage();
 void EGEAPI setinitmode(int mode, int x = CW_USEDEFAULT, int y = CW_USEDEFAULT);

--- a/src/image.h
+++ b/src/image.h
@@ -213,6 +213,6 @@ public:
     friend void getimage_from_png_struct(PIMAGE, void*, void*);
 };
 
-int getimage_from_bitmap(PIMAGE pimg, Gdiplus::Bitmap& bitmap);
+int getimage_from_bitmap(PIMAGE pimg, Gdiplus::Bitmap& bitmap, bool regardRGB32asARGB = true);
 
 } // namespace ege


### PR DESCRIPTION
- RGB32 格式为 32 位 RGB 格式，在 RGB24 的基础上添加一个不使用的字节，对齐 32 位从而加快处理速度。
- RGB32 格式有时也会当做 ARGB 格式使用，将其预留通道视为透明通道。在 GDI+ 中，将 RGB32 格式转换成 ARGB 格式会将 alpha 通道赋值为 0xFF，丢失其原有数据。

**默认**：将 RGB32 格式视为 ARGB，保留其原有数据。
