### PR TITLE
Fix: 修复在 inigraph() 之前调用 newimage()  会引起程序崩溃的问题

### DIFF
--- a/src/ege_graph.h
+++ b/src/ege_graph.h
@@ -30,4 +30,7 @@ int waitdealmessage(_graph_setting* pg);
 float EGE_PRIVATE_GetFPS(int add); // 获取帧数
 
 void setmode(int gdriver, int gmode);
+
+// GDI+ 初始化
+void gdipluinit();
 }

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -713,8 +713,7 @@ inline void init_img_page(struct _graph_setting* pg)
 {
     if (!pg->has_init) {
 #ifdef EGE_GDIPLUS
-        Gdiplus::GdiplusStartupInput gdiplusStartupInput;
-        Gdiplus::GdiplusStartup(&pg->g_gdiplusToken, &gdiplusStartupInput, NULL);
+    gdipluinit();
 #endif
     }
 }
@@ -1013,6 +1012,14 @@ int getinitmode()
 long getGraphicsVer()
 {
     return EGE_VERSION_NUMBER;
+}
+
+void gdipluinit()
+{
+    if (graph_setting.g_gdiplusToken == 0) {
+        Gdiplus::GdiplusStartupInput gdiplusStartupInput;
+        Gdiplus::GdiplusStartup(&graph_setting.g_gdiplusToken, &gdiplusStartupInput, NULL);
+    }
 }
 
 } // namespace ege

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -61,6 +61,7 @@ void IMAGE::construct(int width, int height)
         refDC = ::GetDC(graph_setting.hwnd);
     }
 
+    gdipluinit();
     reset();
     initimage(refDC, width, height);
     setdefaultattribute();


### PR DESCRIPTION
 原因: 在创建图像时创建了 GDI+ 对象但并未在此之前对 GDI+ 进行初始化 。#59 中引入(083423f)