### PR TITLE
chore: 屏蔽 "libpng warning: iCCP: known incorrect sRGB profile" 警告

### DIFF
--- a/src/image.cpp
+++ b/src/image.cpp
@@ -495,6 +495,11 @@ void getimage_from_png_struct(PIMAGE self, void* vpng_ptr, void* vinfo_ptr)
     png_structp png_ptr  = (png_structp)vpng_ptr;
     png_infop   info_ptr = (png_infop)vinfo_ptr;
 
+    #if defined(PNG_SKIP_sRGB_CHECK_PROFILE) && defined(PNG_SET_OPTION_SUPPORTED)
+    png_set_option(png_ptr, PNG_SKIP_sRGB_CHECK_PROFILE,
+           PNG_OPTION_ON);
+    #endif
+
     // 读取 PNG 文件信息, 存入 info_ptr 中
     png_read_info(png_ptr, info_ptr);
 


### PR DESCRIPTION
1.  加载 PNG 图片时很可能会在控制台中弹出大批量的 "libpng warning: iCCP: known incorrect sRGB profile" 警告，十分影响控制条输入输出、调试和阅读。 

2. 各个浏览器、图像软件的做法一般都是直接忽略颜色空间信息以 sRGB 颜色空间进行显示。
3. 图像软件在保存时，有时会嵌入颜色空间信息，一般都是各自默认的颜色空间，这些颜色空间其实都是 sRGB。作为专业的图像处理软件，肯定考虑到了 PNG 图像在各个软件中显示的问题。由图像软件生成的图像有很大的可能会在这个图像软件上再次编辑，这个颜色空间在该软件中就是最正确的，没必要让用户进行修改，否则图像软件可能还会提示让用户转换回该软件默认的颜色空间。

根据官方手册中提供的方法 ([libpng-manual](https://github.com/pnggroup/libpng/blob/f1848a3b560ddcad065242268433af475948461e/libpng-manual.txt#L5122)) 进行屏蔽。