### PR TITLE
Feat: 增加 flushwindow() 函数, 用于将后台帧缓冲中的内容显示到窗口

### DIFF
--- a/include/ege.h
+++ b/include/ege.h
@@ -856,6 +856,7 @@ int  EGEAPI attachHWND(HWND hWnd);
 
 void EGEAPI movewindow(int x, int y, bool redraw = true);
 void EGEAPI resizewindow(int width, int height);
+void EGEAPI flushwindow();
 
 void EGEAPI setrendermode(rendermode_e mode);
 

--- a/src/ege_graph.h
+++ b/src/ege_graph.h
@@ -33,4 +33,9 @@ void setmode(int gdriver, int gmode);
 
 // GDI+ 初始化
 void gdipluinit();
+
+int  swapbuffers();
+
+bool isinitialized();
+
 }

--- a/src/egegapi.cpp
+++ b/src/egegapi.cpp
@@ -26,7 +26,6 @@
 #include "ege_extension.h"
 
 
-
 #include <stdio.h>
 
 namespace ege
@@ -39,6 +38,11 @@ bool is_run()
         return false;
     }
     return true;
+}
+
+bool isinitialized()
+{
+    return graph_setting.has_init;
 }
 
 int showmouse(int bShow)

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -139,6 +139,7 @@ static void ui_msg_process(EGEMSG& qmsg)
 }
 
 /*private function*/
+/*
 static int redraw_window(_graph_setting* pg, HDC dc)
 {
     int page = pg->visual_page;
@@ -151,6 +152,27 @@ static int redraw_window(_graph_setting* pg, HDC dc)
     pg->update_mark_count = UPDATE_MAX_CALL;
     return 0;
 }
+*/
+
+int swapbuffers()
+{
+    if (!isinitialized())
+        return grNoInitGraph;
+
+    struct _graph_setting* pg = &graph_setting;
+
+    PIMAGE backFrameBuffer = pg->img_page[pg->visual_page];
+    HDC backFrameBufferDC = backFrameBuffer->getdc();
+
+    int left = backFrameBuffer->m_vpt.left;
+    int top  = backFrameBuffer->m_vpt.top;
+
+    HDC frontFrameBufferDC = GetDC(getHWnd());
+    BitBlt(frontFrameBufferDC, 0, 0, pg->base_w, pg->base_h, backFrameBufferDC, pg->base_x - left, pg->base_y - top, SRCCOPY);
+    ReleaseDC(getHWnd(), frontFrameBufferDC);
+
+    return grOk;
+}
 
 /*private function*/
 static int graphupdate(_graph_setting* pg)
@@ -158,41 +180,41 @@ static int graphupdate(_graph_setting* pg)
     if (pg->exit_window) {
         return grNoInitGraph;
     }
-    {
-        if (IsWindowVisible(pg->hwnd)) {
-            HDC hdc = ::GetDC(pg->hwnd);
-            redraw_window(pg, hdc);
-            ::ReleaseDC(pg->hwnd, hdc);
-        } else {
-            pg->update_mark_count = UPDATE_MAX_CALL;
-        }
-        EGE_PRIVATE_GetFPS(0x100);
-        {
-            RECT rect, crect;
-            HWND hwnd;
-            int  _dw, _dh;
-            GetClientRect(pg->hwnd, &crect);
-            GetWindowRect(pg->hwnd, &rect);
-            int w = pg->dc_w, h = pg->dc_h;
-            _dw = w - (crect.right - crect.left);
-            _dh = h - (crect.bottom - crect.top);
-            if (_dw != 0 || _dh != 0) {
-                hwnd = ::GetParent(pg->hwnd);
-                if (hwnd) {
-                    POINT pt = {0, 0};
-                    ClientToScreen(hwnd, &pt);
-                    rect.left   -= pt.x;
-                    rect.top    -= pt.y;
-                    rect.right  -= pt.x;
-                    rect.bottom -= pt.y;
-                }
-                SetWindowPos(pg->hwnd, NULL, 0, 0, rect.right + _dw - rect.left, rect.bottom + _dh - rect.top,
-                    SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOOWNERZORDER | SWP_NOZORDER);
-            }
-        }
 
-        return grOk;
+    if (IsWindowVisible(pg->hwnd)) {
+        swapbuffers();
     }
+
+    pg->update_mark_count = UPDATE_MAX_CALL;
+
+    EGE_PRIVATE_GetFPS(0x100);
+
+    RECT rect, crect;
+    HWND hwnd;
+    int  _dw, _dh;
+
+    GetClientRect(pg->hwnd, &crect);
+    GetWindowRect(pg->hwnd, &rect);
+    int w = pg->dc_w, h = pg->dc_h;
+    _dw = w - (crect.right - crect.left);
+    _dh = h - (crect.bottom - crect.top);
+
+    if (_dw != 0 || _dh != 0) {
+        hwnd = ::GetParent(pg->hwnd);
+        if (hwnd) {
+            POINT pt = {0, 0};
+            ClientToScreen(hwnd, &pt);
+            rect.left   -= pt.x;
+            rect.top    -= pt.y;
+            rect.right  -= pt.x;
+            rect.bottom -= pt.y;
+        }
+        SetWindowPos(pg->hwnd, NULL, 0, 0, rect.right + _dw - rect.left, rect.bottom + _dh - rect.top,
+            SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOOWNERZORDER | SWP_NOZORDER);
+    }
+
+    return grOk;
+
 }
 
 int dealmessage(_graph_setting* pg, bool force_update)

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -58,6 +58,16 @@ void movewindow(int x, int y, bool redraw)
     ::MoveWindow(getHWnd(), x, y, getwidth(), getheight(), redraw);
 }
 
+void flushwindow()
+{
+    if (!isinitialized())
+        return;
+    struct _graph_setting* pg = &graph_setting;
+    pg->skip_timer_mark = true;
+    swapbuffers();
+    pg->skip_timer_mark = false;
+}
+
 HWND getParentWindow()
 {
     return g_attach_hwnd;


### PR DESCRIPTION
功能为将当前显示页(Visual Page)中的图像数据复制到窗口帧缓冲区。

- 在默认不设置绘图页的情况下, 用于显示和绘图的是同一个绘图页, 所以这个能够将绘图内容直接显示到窗口上,。

- 如果用户主动改变了绘图页,则需要用户自己控制显示页, 在绘图完成后, 将显示页和绘图页进行切换后再调用 flushwindow() 进行刷新