### PR TITLE
修改build_commands.bat以支持vs2022快速构建

### DIFF
--- a/build_commands.bat
+++ b/build_commands.bat
@@ -67,6 +67,10 @@ cmake --build build\vs2019 --config Release -j
 cmake -G "Visual Studio 16 2019" -A x64 -S . -B build\vs2019_64 -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELEASE="%CD%\build\lib\vs2019\x64"
 cmake --build build\vs2019_64 --config Release -j
 
+:: Visual Studio 2022 32bit
+cmake -G "Visual Studio 17 2022" -A Win32 -S . -B build\vs2022 -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELEASE="%CD%\build\lib\vs2022\x86"
+cmake --build build\vs2022 --config Release -j
+
 :: Visual Studio 2022 64bit
 cmake -G "Visual Studio 17 2022" -A x64 -S . -B build\vs2022_64 -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELEASE="%CD%\build\lib\vs2022\x64"
 cmake --build build\vs2022_64 --config Release -j

--- a/build_commands.bat
+++ b/build_commands.bat
@@ -1,4 +1,4 @@
-:: ÒÔÏÂÃüÁîÓÃÓÚ½«¸÷°æ±¾¿âÎÄ¼ş·½±ãµØÊä³öµ½ build\lib ÖĞ
+:: ä»¥ä¸‹å‘½ä»¤ç”¨äºå°†å„ç‰ˆæœ¬åº“æ–‡ä»¶æ–¹ä¾¿åœ°è¾“å‡ºåˆ° build\lib ä¸­
 
 
 :: MinGW
@@ -67,8 +67,12 @@ cmake --build build\vs2019 --config Release -j
 cmake -G "Visual Studio 16 2019" -A x64 -S . -B build\vs2019_64 -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELEASE="%CD%\build\lib\vs2019\x64"
 cmake --build build\vs2019_64 --config Release -j
 
+:: Visual Studio 2022 64bit
+cmake -G "Visual Studio 17 2022" -A x64 -S . -B build\vs2022_64 -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELEASE="%CD%\build\lib\vs2022\x64"
+cmake --build build\vs2022_64 --config Release -j
+
 :: Visual C++ 6.0
-:: ÇëÊ¹ÓÃ CMD Ö´ĞĞ
-:: Ö´ĞĞÃüÁîÇ°ÇëÈ·±£°´ BUILD.md ÖĞ `±àÒëÅäÖÃ -- Visual C++ 6.0` Ò»½Ú×öºÃÉèÖÃ
+:: è¯·ä½¿ç”¨ CMD æ‰§è¡Œ
+:: æ‰§è¡Œå‘½ä»¤å‰è¯·ç¡®ä¿æŒ‰ BUILD.md ä¸­ `ç¼–è¯‘é…ç½® -- Visual C++ 6.0` ä¸€èŠ‚åšå¥½è®¾ç½®
 cmake -G "NMake Makefiles" -S . -B build\vc6 -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY="%CD%\build\lib\vc6" -DCMAKE_BUILD_TYPE=Release
 cmake --build build\vc6


### PR DESCRIPTION
如题。build_commands.bat总体上仍然正常工作，但其上次更新为四年前以至于尚未支持vs2022的自动构建。

尽管vs2019的库文件与vs2022的库文件兼容，但在只安装了vs2022而未安装vs2019时此脚本不会正确产生库文件，出于本库定位为初学者库的关系，不妨简单地增加此功能。

主要改动是增加了如下一句：
```bat
:: Visual Studio 2022 64bit
cmake -G "Visual Studio 17 2022" -A x64 -S . -B build\vs2022_64 -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELEASE="%CD%\build\lib\vs2022\x64"
cmake --build build\vs2022_64 --config Release -j
```

经本地测试能够正常产生64位时的lib文件，且库正常工作。