### PR TITLE
fix compile error on mingw-w64 (rename Windows.h => windows.h)

### DIFF
--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -3,7 +3,7 @@
 #include "ege_head.h"
 #include "ege_common.h"
 
-#include <Windows.h>
+#include <windows.h>
 
 namespace ege
 {

--- a/src/ege_dllimport.h
+++ b/src/ege_dllimport.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Windows.h>
+#include <windows.h>
 #include <windef.h>
 
 namespace dll

--- a/src/encodeconv.cpp
+++ b/src/encodeconv.cpp
@@ -6,7 +6,7 @@
 #include "encodeconv.h"
 #include "ege_head.h"
 
-#include <Windows.h>
+#include <windows.h>
 
 namespace ege
 {

--- a/src/image.h
+++ b/src/image.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "ege_head.h"
-#include <Windows.h>
+#include <windows.h>
 
 
 namespace ege

--- a/src/type.h
+++ b/src/type.h
@@ -8,7 +8,7 @@
 #include "stdint.h"
 #endif
 
-#include <Windows.h>
+#include <windows.h>
 
 #if !defined(EGE_W64)
 #if !defined(__midl) && (defined(_X86_) || defined(_M_IX86)) && _MSC_VER >= 1300

--- a/src/window.h
+++ b/src/window.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Windows.h>
+#include <windows.h>
 #include <windef.h>
 #include "type.h"
 #include <string>


### PR DESCRIPTION
解决在 mingw-w64 下的编译问题。