### PR TITLE
fix: 修复 drawpoly(), ege_drawpoly() 在绘制形成多边形的闭合折线时首尾连接处无拐角的情况

### DIFF
--- a/src/egegapi.cpp
+++ b/src/egegapi.cpp
@@ -1286,7 +1286,14 @@ void ege_drawpoly(int numpoints, ege_point* polypoints, PIMAGE pimg)
         }
         Gdiplus::Graphics* graphics = img->getGraphics();
         Gdiplus::Pen* pen = img->getPen();
-        graphics->DrawLines(pen, (Gdiplus::PointF*)polypoints, numpoints);
+
+        /* 当首尾顶点为同一坐标时转成多边形，否则绘制折线 */
+        if (numpoints >= 4 && polypoints[0].x == polypoints[numpoints-1].x
+            && polypoints[0].y == polypoints[numpoints-1].y) {
+            graphics->DrawPolygon(pen, (Gdiplus::PointF*)polypoints, numpoints - 1);
+        } else {
+            graphics->DrawLines(pen, (Gdiplus::PointF*)polypoints, numpoints);
+        }
     }
     CONVERT_IMAGE_END;
 }

--- a/src/egegapi.cpp
+++ b/src/egegapi.cpp
@@ -866,7 +866,16 @@ void drawpoly(int numpoints, const int* polypoints, PIMAGE pimg)
 {
     PIMAGE img = CONVERT_IMAGE(pimg);
     if (img) {
-        Polyline(img->m_hDC, (POINT*)polypoints, numpoints);
+        const POINT* points = (const POINT*)polypoints;
+        /* 闭合曲线, 转为绘制带边框无填充多边形 */
+        if ((numpoints > 3) && (points[0].x == points[numpoints-1].x)
+                && (points[0].y == points[numpoints-1].y)) {
+            HBRUSH oldBrush = (HBRUSH)SelectObject(img->m_hDC, GetStockObject(NULL_BRUSH));
+            Polygon(img->m_hDC, points, numpoints - 1);
+            SelectObject(img->m_hDC, oldBrush);
+        } else {
+            Polyline(img->m_hDC, (POINT*)polypoints, numpoints);
+        }
     }
     CONVERT_IMAGE_END;
 }

--- a/src/egegapi.cpp
+++ b/src/egegapi.cpp
@@ -1297,7 +1297,7 @@ void ege_drawpoly(int numpoints, ege_point* polypoints, PIMAGE pimg)
         Gdiplus::Pen* pen = img->getPen();
 
         /* 当首尾顶点为同一坐标时转成多边形，否则绘制折线 */
-        if (numpoints >= 4 && polypoints[0].x == polypoints[numpoints-1].x
+        if (numpoints > 3 && polypoints[0].x == polypoints[numpoints-1].x
             && polypoints[0].y == polypoints[numpoints-1].y) {
             graphics->DrawPolygon(pen, (Gdiplus::PointF*)polypoints, numpoints - 1);
         } else {


### PR DESCRIPTION
drawpoly() 和 ege_drawpoly() 内部都使用 折线 PolyLine 来实现,。如果直线线帽和直线连接样式为圆角，那么首尾连接处不进行额外处理也是可以正常连接的，但是如果是斜角和尖角的就出问题。
所以这里对首先连接的闭合折线使用 Polygon() 来进行绘制