### PR TITLE
Typo: 纠正 setfillcolor() 创建画刷时赋值对象不正确的错误

### DIFF
--- a/src/egegapi.cpp
+++ b/src/egegapi.cpp
@@ -541,7 +541,7 @@ void setfillcolor(color_t color, PIMAGE pimg)
     LOGBRUSH lbr = {0};
     img->m_fillcolor = color;
     lbr.lbColor = ARGBTOZBGR(color);
-    lbr.lbHatch = BS_SOLID;
+    lbr.lbStyle = BS_SOLID;
     HBRUSH hbr = CreateBrushIndirect(&lbr);
     if (hbr) {
         DeleteObject(SelectObject(img->m_hDC, hbr));

--- a/src/egegapi.cpp
+++ b/src/egegapi.cpp
@@ -538,11 +538,8 @@ void setcolor(color_t color, PIMAGE pimg)
 void setfillcolor(color_t color, PIMAGE pimg)
 {
     PIMAGE img = CONVERT_IMAGE_CONST(pimg);
-    LOGBRUSH lbr = {0};
     img->m_fillcolor = color;
-    lbr.lbColor = ARGBTOZBGR(color);
-    lbr.lbStyle = BS_SOLID;
-    HBRUSH hbr = CreateBrushIndirect(&lbr);
+    HBRUSH hbr = CreateSolidBrush(ARGBTOZBGR(color));
     if (hbr) {
         DeleteObject(SelectObject(img->m_hDC, hbr));
     }


### PR DESCRIPTION
改为使用语义更为清晰的 CreateSolidBrush() 来创建画刷