### PR TITLE
Adjust: 消除 alphablend 误差

### DIFF
--- a/include/ege.h
+++ b/include/ege.h
@@ -908,10 +908,14 @@ void    EGEAPI putpixel_f (int x, int y, color_t color, PIMAGE pimg = NULL);
 void    EGEAPI putpixels  (int numOfPoints, int* points, PIMAGE pimg = NULL);
 void    EGEAPI putpixels_f(int numOfPoints, int* points, PIMAGE pimg = NULL);
 
-void    EGEAPI putpixel_withalpha  (int x, int y, color_t color, PIMAGE pimg = NULL);
-void    EGEAPI putpixel_withalpha_f(int x, int y, color_t color, PIMAGE pimg = NULL);
-void    EGEAPI putpixel_savealpha  (int x, int y, color_t color, PIMAGE pimg = NULL);
-void    EGEAPI putpixel_savealpha_f(int x, int y, color_t color, PIMAGE pimg = NULL);
+void    EGEAPI putpixel_withalpha   (int x, int y, color_t color, PIMAGE pimg = NULL);
+void    EGEAPI putpixel_withalpha_f (int x, int y, color_t color, PIMAGE pimg = NULL);
+void    EGEAPI putpixel_savealpha   (int x, int y, color_t color, PIMAGE pimg = NULL);
+void    EGEAPI putpixel_savealpha_f (int x, int y, color_t color, PIMAGE pimg = NULL);
+void    EGEAPI putpixel_alphablend  (int x, int y, color_t color, PIMAGE pimg = NULL);
+void    EGEAPI putpixel_alphablend_f(int x, int y, color_t color, PIMAGE pimg = NULL);
+void    EGEAPI putpixel_alphablend  (int x, int y, color_t color, unsigned char alphaFactor, PIMAGE pimg = NULL);
+void    EGEAPI putpixel_alphablend_f(int x, int y, color_t color, unsigned char alphaFactor, PIMAGE pimg = NULL);
 
 void    EGEAPI moveto (int x,  int y,  PIMAGE pimg = NULL);
 void    EGEAPI moverel(int dx, int dy, PIMAGE pimg = NULL);

--- a/include/ege.h
+++ b/include/ege.h
@@ -806,7 +806,7 @@ class IMAGE;
 typedef IMAGE *PIMAGE;
 typedef const IMAGE *PCIMAGE;
 
-// `codepage` sholde be `EGE_CODEPAGE_XXX`, default is `EGE_CODEPAGE_ANSI`.
+// `codepage` should be `EGE_CODEPAGE_XXX`, default is `EGE_CODEPAGE_ANSI`.
 void EGEAPI setcodepage(unsigned int codepage);
 unsigned int EGEAPI getcodepage();
 // set whether char message of `getkey()` use UTF-16
@@ -890,15 +890,16 @@ void    EGEAPI setbkmode(int bkMode, PIMAGE pimg = NULL);
 #define HSLtoRGB    hsl2rgb
 #define HSVtoRGB    hsv2rgb
 
-color_t     EGEAPI rgb2gray(color_t rgb);
-void        EGEAPI rgb2hsl(color_t rgb, float* H, float* S, float* L);
-void        EGEAPI rgb2hsv(color_t rgb, float* H, float* S, float* V);
-color_t     EGEAPI hsl2rgb(float H, float S, float L);
-color_t     EGEAPI hsv2rgb(float H, float S, float V);
+color_t EGEAPI rgb2gray(color_t rgb);
+void    EGEAPI rgb2hsl(color_t rgb, float* H, float* S, float* L);
+void    EGEAPI rgb2hsv(color_t rgb, float* H, float* S, float* V);
+color_t EGEAPI hsl2rgb(float H, float S, float L);
+color_t EGEAPI hsv2rgb(float H, float S, float V);
 
-color_t     EGEAPI alphablend(color_t dst, color_t src);
-color_t     EGEAPI alphablend(color_t dst, color_t src, unsigned char alpha);
-
+color_t EGEAPI colorblend  (color_t dst, color_t src, unsigned char alpha);
+color_t EGEAPI colorblend_f(color_t dst, color_t src, unsigned char alpha);
+color_t EGEAPI alphablend  (color_t dst, color_t src);
+color_t EGEAPI alphablend  (color_t dst, color_t src, unsigned char srcAlphaFactor);
 
 color_t EGEAPI getpixel   (int x, int y, PCIMAGE pimg = NULL);
 void    EGEAPI putpixel   (int x, int y, color_t color, PIMAGE pimg = NULL);
@@ -1002,12 +1003,9 @@ void EGEAPI ege_drawimage(PCIMAGE imgSrc,int xDest, int yDest, int widthDest, in
 // matrix for transformation
 typedef struct ege_transform_matrix
 {
-    float m11;
-    float m12;
-    float m21;
-    float m22;
-    float m31;
-    float m32;
+    float m11, m12;
+    float m21, m22;
+    float m31, m32;
 } ege_transform_matrix;
 
 // transforms
@@ -1213,7 +1211,7 @@ int EGEAPI putimage_alphafilter(
     int heightSrc               // height of source rectangle
 );
 int EGEAPI imagefilter_blurring (
-    PIMAGE imgDest,             // handle to dest
+    PIMAGE imgDest,
     int intensity,
     int alpha,
     int xDest = 0,
@@ -1257,7 +1255,7 @@ int EGEAPI putimage_rotatetransparent(
     int yCenterSrc,             /* y-coord of rotation center in source */
     color_t transparentColor,   /* color to make transparent */
     float radian,               /* rotation angle (clockwise, in radian) */
-    float zoom=1.0              /* zoom factor */
+    float zoom = 1.0f           /* zoom factor */
 );
 
 int EGEAPI putimage_rotatetransparent(
@@ -1273,7 +1271,7 @@ int EGEAPI putimage_rotatetransparent(
     int yCenterSrc,             /* y-coord of rotation center in source */
     color_t transparentColor,   /* color to make transparent */
     float radian,               /* rotation angle (clockwise, in radian) */
-    float zoom = 1.0            /* zoom factor */
+    float zoom = 1.0f           /* zoom factor */
 );
 
 HWND        EGEAPI getHWnd();

--- a/src/color.cpp
+++ b/src/color.cpp
@@ -354,12 +354,22 @@ color_t hsv2rgb(float H, float S, float V)
 
 color_t alphablend(color_t dst, color_t src)
 {
-    return alphablend_inline(dst, src, EGEGET_A(src));
+    return alphablend_inline(dst, src);
 }
 
 color_t alphablend(color_t dst, color_t src, unsigned char alpha)
 {
     return alphablend_inline(dst, src, alpha);
+}
+
+color_t alphablend_f(color_t dst, color_t src)
+{
+    return alphablend_inline_fast(dst, src);
+}
+
+color_t alphablend_f(color_t dst, color_t src, unsigned char alpha)
+{
+    return alphablend_inline_fast(dst, src, alpha);
 }
 
 } // namespace ege

--- a/src/color.cpp
+++ b/src/color.cpp
@@ -352,24 +352,24 @@ color_t hsv2rgb(float H, float S, float V)
     return EGERGB(crgb.r, crgb.g, crgb.b);
 }
 
+color_t colorblend(color_t dst, color_t src, unsigned char alpha)
+{
+    return colorblend_inline(dst, src, alpha);
+}
+
+color_t colorblend_f(color_t dst, color_t src, unsigned char alpha)
+{
+    return colorblend_inline_fast(dst, src, alpha);
+}
+
 color_t alphablend(color_t dst, color_t src)
 {
     return alphablend_inline(dst, src);
 }
 
-color_t alphablend(color_t dst, color_t src, unsigned char alpha)
+color_t alphablend(color_t dst, color_t src, unsigned char srcAlphaFactor)
 {
-    return alphablend_inline(dst, src, alpha);
-}
-
-color_t alphablend_f(color_t dst, color_t src)
-{
-    return alphablend_inline_fast(dst, src);
-}
-
-color_t alphablend_f(color_t dst, color_t src, unsigned char alpha)
-{
-    return alphablend_inline_fast(dst, src, alpha);
+    return alphablend_inline(dst, src, srcAlphaFactor);
 }
 
 } // namespace ege

--- a/src/color.h
+++ b/src/color.h
@@ -5,11 +5,10 @@
 #include "ege_math.h"
 #include "type.h"
 
-// 0xaarrggbb -> 0xaabbggrr
+// 交换颜色中 R 通道和 B 通道: 0xAARRGGBB -> 0xAABBGGRR
 #define RGBTOBGR(color) ((color_t)((((color) & 0xFF) << 16) | (((color) & 0xFF0000) >> 16) | ((color) & 0xFF00FF00)))
 
-// 将 color_t 与 Bitmap Buffer 所用的 0xaarrggbb 格式
-// 转换为 COLORREF 所用的 0x00bbggrr，忽略 Alpha 通道
+// 将 color_t 与 Bitmap Buffer 所用的 0xAARRGGBB 格式转换为 COLORREF 的 0x00BBGGRR 格式
 // 仅用于向 GDI32 API 传递颜色时
 #define ARGBTOZBGR(c) ((color_t)((((c) & 0xFF) << 16) | (((c) & 0xFF0000) >> 16) | ((c) & 0xFF00)))
 
@@ -43,64 +42,102 @@ typedef struct COLORRGB
 } COLORRGB;
 
 /**
- * @brief 以 dst 为背景色，src 为前景色进行混合
+ * @brief RGB 颜色混合，混合结果保留背景色透明通道
  *
- * @param dst 背景颜色
- * @param src 前景色
- * @param alpha 不透明度(0~255)
- * @return color_t: 混合后的颜色，保留 dst 的透明通道
+ * @param dst   背景色(RGB)
+ * @param src   前景色(RGB)
+ * @param alpha 透明度(0~255)
+ * @return      混合后的 RGB 颜色，透明度与背景色一致
  */
-EGE_FORCEINLINE color_t alphablend_inline_fast(color_t dst, color_t src, byte alpha)
+EGE_FORCEINLINE color_t colorblend_inline(color_t dst, color_t src, byte alpha)
 {
+    byte r = DIVIDE_255_FAST(255 * EGEGET_R(dst) + ((int)(EGEGET_R(src) - EGEGET_R(dst)) * alpha + 255/2));
+    byte g = DIVIDE_255_FAST(255 * EGEGET_G(dst) + ((int)(EGEGET_G(src) - EGEGET_G(dst)) * alpha + 255/2));
+    byte b = DIVIDE_255_FAST(255 * EGEGET_B(dst) + ((int)(EGEGET_B(src) - EGEGET_B(dst)) * alpha + 255/2));
+
+    return EGEARGB(EGEGET_A(dst),r, g, b);
+}
+
+/**
+ * @brief RGB 颜色混合，混合结果保留背景色透明通道
+ *
+ * @param dst   背景色(RGB)
+ * @param src   前景色(RGB)
+ * @param alpha 透明度(0~255)
+ * @return      混合后的 RGB 颜色，透明度与背景色一致
+ * @note        结果与标准公式相比有一定误差
+ */
+EGE_FORCEINLINE color_t colorblend_inline_fast(color_t dst, color_t src, byte alpha)
+{
+#define COLORBLEND_INLINE_FAST_OPTION  1
+#if COLORBLEND_INLINE_FAST_OPTION == 0
+    // 误差较大，可能取不到端点，而且无近似取整
     uint32_t rb = dst & 0x00FF00FF;
     uint32_t g  = dst & 0x0000FF00;
 
     rb += ((src & 0x00FF00FF) - rb) * alpha >> 8;
     g  += ((src & 0x0000FF00) - g ) * alpha >> 8;
     return (rb & 0x00FF00FF) | (g & 0x0000FF00) | (dst & 0xFF000000);
+#elif COLORBLEND_INLINE_FAST_OPTION == 1
+    // 有近似取整，端点正常，误差较小
+    uint32_t rb = dst & 0x00FF00FF;
+    uint32_t g  = dst & 0x0000FF00;
+    int alphaFactor = DIVIDE_255_FAST((alpha << 8) + 255/2);
+
+    rb += (((src & 0x00FF00FF) - rb) * alphaFactor + 0x007F007F) >> 8;
+    g  += (((src & 0x0000FF00) - g ) * alphaFactor + 0x00007F00) >> 8;
+    return (dst & 0xFF000000) | (rb & 0x00FF00FF) | (g & 0x0000FF00);
+#endif
+#undef COLORBLEND_INLINE_FAST_OPTION
 }
 
 /**
- * @brief 以 dst 为背景色，src 为前景色进行混合, alpha 取自前景色 src 的透明通道
+ * @brief 将两个 ARGB 颜色以指定的 alpha 进行混合 (忽略前景色透明度)
  *
- * @param dst 背景色
- * @param src 前景色
- * @return color_t: 混合后的颜色，保留 dst 的透明通道
- */
-EGE_FORCEINLINE color_t alphablend_inline_fast(color_t dst, color_t src)
-{
-    return alphablend_inline_fast(dst, src, EGEGET_A(src));
-}
-
-//
-// RGB   = alpha * RGB(src) + (1.0 - alpha) * RGB(dst);
-// alpha = alpha + (1.0 - alpha) * A(dst)
-/**
- * @brief 以 dst 为背景色，src 为前景色进行混合
- *
- * @param dst 背景色
- * @param src 前景色
- * @param alpha 不透明度(0~255)
- * @return color_t: 混合后的颜色
- * @note 计算公式:
- * A = A(dst) + alpha * （1.0    - A(dst));
+ * @param dst   背景色(ARGB)
+ * @param src   前景色(ARGB)
+ * @param alpha 透明度(0~255)
+ * @return      混合后的 ARGB 颜色
+ * @note 混合公式 (公式中 alpha 为 0.0~1.0):
+ * A = A(dst) + alpha * （255    - A(dst));
  * R = R(dst) + alpha * （R(src) - R(dst));
  * G = G(dst) + alpha * （G(src) - G(dst));
  * B = B(dst) + alpha * （B(src) - B(dst));
  */
-EGE_FORCEINLINE color_t alphablend_inline(color_t dst, color_t src, byte alpha)
+EGE_FORCEINLINE color_t alphablend_specify_inline(color_t dst, color_t src, byte alpha)
 {
-    const byte a = DIVIDE_255_FAST(255 * EGEGET_A(dst) + (255 - EGEGET_A(dst)) * alpha + 127);
-    const byte r = DIVIDE_255_FAST(255 * EGEGET_R(dst) + ((int)(EGEGET_R(src) - EGEGET_R(dst)) * alpha + 127));
-    const byte g = DIVIDE_255_FAST(255 * EGEGET_G(dst) + ((int)(EGEGET_G(src) - EGEGET_G(dst)) * alpha + 127));
-    const byte b = DIVIDE_255_FAST(255 * EGEGET_B(dst) + ((int)(EGEGET_B(src) - EGEGET_B(dst)) * alpha + 127));
+    const byte a = DIVIDE_255_FAST(255 * EGEGET_A(dst) + ((int)(          255 - EGEGET_A(dst)) * alpha + 255/2));
+    const byte r = DIVIDE_255_FAST(255 * EGEGET_R(dst) + ((int)(EGEGET_R(src) - EGEGET_R(dst)) * alpha + 255/2));
+    const byte g = DIVIDE_255_FAST(255 * EGEGET_G(dst) + ((int)(EGEGET_G(src) - EGEGET_G(dst)) * alpha + 255/2));
+    const byte b = DIVIDE_255_FAST(255 * EGEGET_B(dst) + ((int)(EGEGET_B(src) - EGEGET_B(dst)) * alpha + 255/2));
 
     return EGEARGB(a, r, g, b);
 }
 
+/**
+ * @brief ARGB 颜色混合 (alpha = 前景色透明度)
+ *
+ * @param dst 背景色
+ * @param src 前景色
+ * @return    混合后的 ARGB 颜色
+ */
 EGE_FORCEINLINE color_t alphablend_inline(color_t dst, color_t src)
 {
-    return alphablend_inline(dst, src, EGEGET_A(src));
+    return alphablend_specify_inline(dst, src, EGEGET_A(src));
+}
+
+/**
+ * @brief  ARGB 颜色混合 (alpha = 前景色透明度 * 比例系数)
+ *
+ * @param dst 背景色(ARGB)
+ * @param src 前景色(ARGB)
+ * @param srcAlphaFactor 前景色的比例系数，0~255 对应 0.0~1.0
+ * @return    混合后的 ARGB 颜色
+ */
+EGE_FORCEINLINE color_t alphablend_inline(color_t dst, color_t src, byte srcAlphaFactor)
+{
+    byte alpha = DIVIDE_255_FAST(EGEGET_A(src) * srcAlphaFactor + 255/2);
+    return alphablend_specify_inline(dst, src, alpha);
 }
 
 } //namespace ege

--- a/src/color.h
+++ b/src/color.h
@@ -2,6 +2,8 @@
 
 #include <windef.h>
 #include "ege_def.h"
+#include "ege_math.h"
+#include "type.h"
 
 // 0xaarrggbb -> 0xaabbggrr
 #define RGBTOBGR(color) ((color_t)((((color) & 0xFF) << 16) | (((color) & 0xFF0000) >> 16) | ((color) & 0xFF00FF00)))
@@ -40,16 +42,65 @@ typedef struct COLORRGB
     unsigned char b;
 } COLORRGB;
 
-// 以 bkg 为背景色，src 为前景色，alpha 为 0~255 的整数进行混合，
-// 混合结果保留 bkg 的 Alpha 通道
-EGE_FORCEINLINE color_t alphablend_inline(color_t bkg, color_t src, unsigned char alpha)
+/**
+ * @brief 以 dst 为背景色，src 为前景色进行混合
+ *
+ * @param dst 背景颜色
+ * @param src 前景色
+ * @param alpha 不透明度(0~255)
+ * @return color_t: 混合后的颜色，保留 dst 的透明通道
+ */
+EGE_FORCEINLINE color_t alphablend_inline_fast(color_t dst, color_t src, byte alpha)
 {
-    DWORD rb = bkg & 0x00FF00FF;
-    DWORD g  = bkg & 0x0000FF00;
+    uint32_t rb = dst & 0x00FF00FF;
+    uint32_t g  = dst & 0x0000FF00;
 
     rb += ((src & 0x00FF00FF) - rb) * alpha >> 8;
-    g  += ((src & 0x0000FF00) - g)  * alpha >> 8;
-    return (rb & 0x00FF00FF) | (g & 0x0000FF00) | (bkg & 0xFF000000);
+    g  += ((src & 0x0000FF00) - g ) * alpha >> 8;
+    return (rb & 0x00FF00FF) | (g & 0x0000FF00) | (dst & 0xFF000000);
+}
+
+/**
+ * @brief 以 dst 为背景色，src 为前景色进行混合, alpha 取自前景色 src 的透明通道
+ *
+ * @param dst 背景色
+ * @param src 前景色
+ * @return color_t: 混合后的颜色，保留 dst 的透明通道
+ */
+EGE_FORCEINLINE color_t alphablend_inline_fast(color_t dst, color_t src)
+{
+    return alphablend_inline_fast(dst, src, EGEGET_A(src));
+}
+
+//
+// RGB   = alpha * RGB(src) + (1.0 - alpha) * RGB(dst);
+// alpha = alpha + (1.0 - alpha) * A(dst)
+/**
+ * @brief 以 dst 为背景色，src 为前景色进行混合
+ *
+ * @param dst 背景色
+ * @param src 前景色
+ * @param alpha 不透明度(0~255)
+ * @return color_t: 混合后的颜色
+ * @note 计算公式:
+ * A = A(dst) + alpha * （1.0    - A(dst));
+ * R = R(dst) + alpha * （R(src) - R(dst));
+ * G = G(dst) + alpha * （G(src) - G(dst));
+ * B = B(dst) + alpha * （B(src) - B(dst));
+ */
+EGE_FORCEINLINE color_t alphablend_inline(color_t dst, color_t src, byte alpha)
+{
+    const byte a = DIVIDE_255_FAST(255 * EGEGET_A(dst) + (255 - EGEGET_A(dst)) * alpha + 127);
+    const byte r = DIVIDE_255_FAST(255 * EGEGET_R(dst) + ((int)(EGEGET_R(src) - EGEGET_R(dst)) * alpha + 127));
+    const byte g = DIVIDE_255_FAST(255 * EGEGET_G(dst) + ((int)(EGEGET_G(src) - EGEGET_G(dst)) * alpha + 127));
+    const byte b = DIVIDE_255_FAST(255 * EGEGET_B(dst) + ((int)(EGEGET_B(src) - EGEGET_B(dst)) * alpha + 127));
+
+    return EGEARGB(a, r, g, b);
+}
+
+EGE_FORCEINLINE color_t alphablend_inline(color_t dst, color_t src)
+{
+    return alphablend_inline(dst, src, EGEGET_A(src));
 }
 
 } //namespace ege

--- a/src/ege_math.h
+++ b/src/ege_math.h
@@ -32,6 +32,11 @@ using std::round;
 #endif  // __cplusplus < 201103L
 
 #else
-// 在低版本 GCC (如 2005-11-30 的 GCC 3.4.5)中 round() 函数也可用
+// round() 函数在低版本 GCC 中可用 (如 2005-11-30 的 GCC 3.4.5)
+
 #endif
+
+// 快除 255，有效范围：[0, 65790)
+#define DIVIDE_255_FAST(x)  (((x) + (((x) + 257) >> 8)) >> 8)
+
 }  // namespace ege

--- a/src/egegapi.cpp
+++ b/src/egegapi.cpp
@@ -185,8 +185,52 @@ void putpixel_savealpha_f(int x, int y, color_t color, PIMAGE pimg)
 {
     PIMAGE img = CONVERT_IMAGE_F(pimg);
     if (in_rect(x, y, img->m_width, img->m_height)) {
-        color_t dst_color = (color_t)img->m_pBuffer[y * img->m_width + x];
+        color_t& dst_color = (color_t&)img->m_pBuffer[y * img->m_width + x];
         dst_color = EGECOLORA(color, EGEGET_A(dst_color));
+    }
+    CONVERT_IMAGE_END;
+}
+
+void putpixel_alphablend(int x, int y, color_t color, PIMAGE pimg)
+{
+    PIMAGE img = CONVERT_IMAGE(pimg);
+    x += img->m_vpt.left;
+    y += img->m_vpt.top;
+    if (in_rect(x, y, img->m_vpt.right, img->m_vpt.bottom)) {
+        color_t& dst_color = (color_t&)img->m_pBuffer[y * img->m_width + x];
+        dst_color = alphablend_inline(dst_color, color);
+    }
+    CONVERT_IMAGE_END;
+}
+
+void putpixel_alphablend_f(int x, int y, color_t color, PIMAGE pimg)
+{
+    PIMAGE img = CONVERT_IMAGE(pimg);
+    if (in_rect(x, y, img->m_width, img->m_height)) {
+        color_t& dst_color = (color_t&)img->m_pBuffer[y * img->m_width + x];
+        dst_color = alphablend_inline(dst_color, color);
+    }
+    CONVERT_IMAGE_END;
+}
+
+void putpixel_alphablend(int x, int y, color_t color, unsigned char alphaFactor, PIMAGE pimg)
+{
+    PIMAGE img = CONVERT_IMAGE(pimg);
+    x += img->m_vpt.left;
+    y += img->m_vpt.top;
+    if (in_rect(x, y, img->m_vpt.right, img->m_vpt.bottom)) {
+        color_t& dst_color = (color_t&)img->m_pBuffer[y * img->m_width + x];
+        dst_color = alphablend_inline(dst_color, color, alphaFactor);
+    }
+    CONVERT_IMAGE_END;
+}
+
+void putpixel_alphablend_f(int x, int y, color_t color, unsigned char alphaFactor, PIMAGE pimg)
+{
+    PIMAGE img = CONVERT_IMAGE(pimg);
+    if (in_rect(x, y, img->m_width, img->m_height)) {
+        color_t& dst_color = (color_t&)img->m_pBuffer[y * img->m_width + x];
+        dst_color = alphablend_inline(dst_color, color, alphaFactor);
     }
     CONVERT_IMAGE_END;
 }

--- a/src/egegapi.cpp
+++ b/src/egegapi.cpp
@@ -164,7 +164,7 @@ void putpixel_withalpha_f(int x, int y, color_t color, PIMAGE pimg)
     PIMAGE img = CONVERT_IMAGE_F(pimg);
     if (in_rect(x, y, img->m_width, img->m_height)) {
         color_t& dst_color = (color_t&)img->m_pBuffer[y * img->m_width + x];
-        dst_color = alphablend_inline(dst_color, color, EGEGET_A(color));
+        dst_color = alphablend_inline_fast(dst_color, color, EGEGET_A(color));
     }
     CONVERT_IMAGE_END;
 }

--- a/src/egegapi.cpp
+++ b/src/egegapi.cpp
@@ -154,7 +154,7 @@ void putpixel_withalpha(int x, int y, color_t color, PIMAGE pimg)
     y += img->m_vpt.top;
     if (in_rect(x, y, img->m_vpt.right, img->m_vpt.bottom)) {
         color_t& dst_color = (color_t&)img->m_pBuffer[y * img->m_width + x];
-        dst_color = alphablend_inline(dst_color, color, EGEGET_A(color));
+        dst_color = colorblend_inline(dst_color, color, EGEGET_A(color));
     }
     CONVERT_IMAGE_END;
 }
@@ -164,7 +164,7 @@ void putpixel_withalpha_f(int x, int y, color_t color, PIMAGE pimg)
     PIMAGE img = CONVERT_IMAGE_F(pimg);
     if (in_rect(x, y, img->m_width, img->m_height)) {
         color_t& dst_color = (color_t&)img->m_pBuffer[y * img->m_width + x];
-        dst_color = alphablend_inline_fast(dst_color, color, EGEGET_A(color));
+        dst_color = colorblend_inline_fast(dst_color, color, EGEGET_A(color));
     }
     CONVERT_IMAGE_END;
 }

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -803,14 +803,8 @@ void IMAGE::putimage(PIMAGE imgDest, int xDest, int yDest, int widthDest, int he
 }
 
 /* private function */
-static void fix_rect_1size(PCIMAGE pdest, PCIMAGE psrc,
-    int* xDest, // x-coord of destination upper-left corner
-    int* yDest, // y-coord of destination upper-left corner
-    int* xSrc,  // x-coord of source upper-left corner
-    int* ySrc,  // y-coord of source upper-left corner
-    int* widthSrc,    // width of source rectangle
-    int* heightSrc    // height of source rectangle
-)
+static void fix_rect_1size(PCIMAGE pdest, PCIMAGE psrc, int* xDest, int* yDest,
+        int* xSrc, int* ySrc, int* widthSrc, int* heightSrc)
 {
     /* prepare viewport region and carry out coordinate transformation */
     struct viewporttype _vpt  = pdest->m_vpt;
@@ -863,14 +857,14 @@ static void fix_rect_1size(PCIMAGE pdest, PCIMAGE psrc,
     }
 }
 
-int IMAGE::putimage_transparent(PIMAGE imgDest,       // handle to dest
-    int                                xDest,  // x-coord of destination upper-left corner
-    int                                yDest,  // y-coord of destination upper-left corner
-    color_t                            transparentColor, // color to make transparent
-    int                                xSrc,   // x-coord of source upper-left corner
-    int                                ySrc,   // y-coord of source upper-left corner
-    int                                widthSrc,     // width of source rectangle
-    int                                heightSrc     // height of source rectangle
+int IMAGE::putimage_transparent(PIMAGE imgDest,           // handle to dest
+    int                                xDest,             // x-coord of destination upper-left corner
+    int                                yDest,             // y-coord of destination upper-left corner
+    color_t                            transparentColor,  // color to make transparent
+    int                                xSrc,              // x-coord of source upper-left corner
+    int                                ySrc,              // y-coord of source upper-left corner
+    int                                widthSrc,          // width of source rectangle
+    int                                heightSrc          // height of source rectangle
 ) const
 {
     inittest(L"IMAGE::putimage_transparent");
@@ -902,14 +896,14 @@ int IMAGE::putimage_transparent(PIMAGE imgDest,       // handle to dest
     return grOk;
 }
 
-int IMAGE::putimage_alphablend(PIMAGE imgDest,      // handle to dest
-    int                               xDest, // x-coord of destination upper-left corner
-    int                               yDest, // y-coord of destination upper-left corner
-    unsigned char                     alpha,        // alpha
-    int                               xSrc,  // x-coord of source upper-left corner
-    int                               ySrc,  // y-coord of source upper-left corner
-    int                               widthSrc,    // width of source rectangle
-    int                               heightSrc    // height of source rectangle
+int IMAGE::putimage_alphablend(PIMAGE imgDest,  // handle to dest
+    int                               xDest,    // x-coord of destination upper-left corner
+    int                               yDest,    // y-coord of destination upper-left corner
+    unsigned char                     alpha,    // alpha
+    int                               xSrc,     // x-coord of source upper-left corner
+    int                               ySrc,     // y-coord of source upper-left corner
+    int                               widthSrc, // width of source rectangle
+    int                               heightSrc // height of source rectangle
 ) const
 {
     inittest(L"IMAGE::putimage_alphablend");
@@ -1007,8 +1001,7 @@ int IMAGE::putimage_withalpha(PIMAGE imgDest,      // handle to dest
         for (y = 0; y < heightSrc; ++y) {
             for (x = 0; x < widthSrc; ++x, ++psp, ++pdp) {
                 DWORD d = *pdp, s = *psp;
-                unsigned char alpha = EGEGET_A(s);
-                *pdp        = alphablend_inline(d, s, alpha);
+                *pdp = alphablend_inline(d, s);
             }
             pdp += ddx;
             psp += dsx;
@@ -1109,12 +1102,12 @@ int IMAGE::putimage_withalpha(PIMAGE imgDest,   // handle to dest
     return grOk;
 }
 
-int IMAGE::putimage_alphafilter(PIMAGE imgDest,      // handle to dest
-    int                                xDest, // x-coord of destination upper-left corner
-    int                                yDest, // y-coord of destination upper-left corner
-    PCIMAGE                            imgAlpha,     // alpha
-    int                                xSrc,  // x-coord of source upper-left corner
-    int                                ySrc,  // y-coord of source upper-left corner
+int IMAGE::putimage_alphafilter(PIMAGE imgDest,     // handle to dest
+    int                                xDest,       // x-coord of destination upper-left corner
+    int                                yDest,       // y-coord of destination upper-left corner
+    PCIMAGE                            imgAlpha,    // alpha
+    int                                xSrc,        // x-coord of source upper-left corner
+    int                                ySrc,        // y-coord of source upper-left corner
     int                                widthSrc,    // width of source rectangle
     int                                heightSrc    // height of source rectangle
 ) const

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
 * EGE (Easy Graphics Engine)
 * filename  image.cpp
 
@@ -803,26 +803,26 @@ void IMAGE::putimage(PIMAGE imgDest, int xDest, int yDest, int widthDest, int he
 }
 
 /* private function */
-static void fix_rect_1size(PCIMAGE pdest, PCIMAGE psrc, int* xDest, int* yDest,
+static void fix_rect_1size(PCIMAGE imgDest, PCIMAGE imgSrc, int* xDest, int* yDest,
         int* xSrc, int* ySrc, int* widthSrc, int* heightSrc)
 {
     /* prepare viewport region and carry out coordinate transformation */
-    struct viewporttype _vpt  = pdest->m_vpt;
+    struct viewporttype _vpt  = imgDest->m_vpt;
     *xDest            += _vpt.left;
     *yDest            += _vpt.top;
     /* default value proc */
     if (*widthSrc == 0) {
-        *widthSrc  = psrc->m_width;
-        *heightSrc = psrc->m_height;
+        *widthSrc  = imgSrc->m_width;
+        *heightSrc = imgSrc->m_height;
     }
     /* fix src rect */
-    if (*widthSrc > psrc->m_width) {
-        *widthSrc -= *widthSrc - psrc->m_width;
-        *widthSrc  = psrc->m_width;
+    if (*widthSrc > imgSrc->m_width) {
+        *widthSrc -= *widthSrc - imgSrc->m_width;
+        *widthSrc  = imgSrc->m_width;
     }
-    if (*heightSrc > psrc->m_height) {
-        *heightSrc -= *heightSrc - psrc->m_height;
-        *heightSrc  = psrc->m_height;
+    if (*heightSrc > imgSrc->m_height) {
+        *heightSrc -= *heightSrc - imgSrc->m_height;
+        *heightSrc  = imgSrc->m_height;
     }
     if (*xSrc < 0) {
         *widthSrc    += *xSrc;
@@ -934,15 +934,15 @@ int IMAGE::putimage_alphablend(PIMAGE imgDest,  // handle to dest
     return grOk;
 }
 
-int IMAGE::putimage_alphatransparent(PIMAGE imgDest,       // handle to dest
-    int                                     xDest,  // x-coord of destination upper-left corner
-    int                                     yDest,  // y-coord of destination upper-left corner
-    color_t                                 transparentColor, // color to make transparent
-    unsigned char                           alpha,         // alpha
-    int                                     xSrc,   // x-coord of source upper-left corner
-    int                                     ySrc,   // y-coord of source upper-left corner
-    int                                     widthSrc,     // width of source rectangle
-    int                                     heightSrc     // height of source rectangle
+int IMAGE::putimage_alphatransparent(PIMAGE imgDest,           // handle to dest
+    int                                     xDest,             // x-coord of destination upper-left corner
+    int                                     yDest,             // y-coord of destination upper-left corner
+    color_t                                 transparentColor,  // color to make transparent
+    unsigned char                           alpha,             // alpha
+    int                                     xSrc,              // x-coord of source upper-left corner
+    int                                     ySrc,              // y-coord of source upper-left corner
+    int                                     widthSrc,          // width of source rectangle
+    int                                     heightSrc          // height of source rectangle
 ) const
 {
     inittest(L"IMAGE::putimage_alphatransparent");
@@ -963,8 +963,8 @@ int IMAGE::putimage_alphatransparent(PIMAGE imgDest,       // handle to dest
         for (y = 0; y < heightSrc; ++y) {
             for (x = 0; x < widthSrc; ++x, ++psp, ++pdp) {
                 if ((*psp & 0x00FFFFFF) != cr) {
-                    DWORD d = *pdp, s = *psp;
-                    *pdp = alphablend_inline(d, s, alpha);
+                    DWORD dst = *pdp, src = *psp;
+                    *pdp = colorblend_inline(dst, src, alpha);
                 }
             }
             pdp += ddx;
@@ -975,13 +975,13 @@ int IMAGE::putimage_alphatransparent(PIMAGE imgDest,       // handle to dest
     return grOk;
 }
 
-int IMAGE::putimage_withalpha(PIMAGE imgDest,      // handle to dest
-    int                              xDest, // x-coord of destination upper-left corner
-    int                              yDest, // y-coord of destination upper-left corner
-    int                              xSrc,  // x-coord of source upper-left corner
-    int                              ySrc,  // y-coord of source upper-left corner
-    int                              widthSrc,    // width of source rectangle
-    int                              heightSrc    // height of source rectangle
+int IMAGE::putimage_withalpha(PIMAGE imgDest,   // handle to dest
+    int                              xDest,     // x-coord of destination upper-left corner
+    int                              yDest,     // y-coord of destination upper-left corner
+    int                              xSrc,      // x-coord of source upper-left corner
+    int                              ySrc,      // y-coord of source upper-left corner
+    int                              widthSrc,  // width of source rectangle
+    int                              heightSrc  // height of source rectangle
 ) const
 {
     inittest(L"IMAGE::putimage_withalpha");
@@ -1000,8 +1000,8 @@ int IMAGE::putimage_withalpha(PIMAGE imgDest,      // handle to dest
         dsx = imgSrc->m_width - widthSrc;
         for (y = 0; y < heightSrc; ++y) {
             for (x = 0; x < widthSrc; ++x, ++psp, ++pdp) {
-                DWORD d = *pdp, s = *psp;
-                *pdp = alphablend_inline(d, s);
+                DWORD dst = *pdp, src = *psp;
+                *pdp = colorblend_inline_fast(dst, src, EGEGET_A(src));
             }
             pdp += ddx;
             psp += dsx;
@@ -1011,16 +1011,16 @@ int IMAGE::putimage_withalpha(PIMAGE imgDest,      // handle to dest
     return grOk;
 }
 
-int IMAGE::putimage_withalpha(PIMAGE imgDest,   // handle to dest
-    int                              xDest,     // x-coord of destination upper-left corner
-    int                              yDest,     // y-coord of destination upper-left corner
-    int                              widthDest, // width of destination rectangle
-    int                              heightDest,// height of destination rectangle
-    int                              xSrc,      // x-coord of source upper-left corner
-    int                              ySrc,      // y-coord of source upper-left corner
-    int                              widthSrc,  // width of source rectangle
+int IMAGE::putimage_withalpha(PIMAGE imgDest,    // handle to dest
+    int                              xDest,      // x-coord of destination upper-left corner
+    int                              yDest,      // y-coord of destination upper-left corner
+    int                              widthDest,  // width of destination rectangle
+    int                              heightDest, // height of destination rectangle
+    int                              xSrc,       // x-coord of source upper-left corner
+    int                              ySrc,       // y-coord of source upper-left corner
+    int                              widthSrc,   // width of source rectangle
     int                              heightSrc,  // height of source rectangle
-    bool                             smooth
+    bool                             smooth      // whether smoothing should be performed
 ) const
 {
     inittest(L"IMAGE::putimage_withalpha");
@@ -1146,19 +1146,19 @@ int IMAGE::putimage_alphafilter(PIMAGE imgDest,     // handle to dest
 }
 
 /* private function */
-static void fix_rect_0size(PIMAGE pdest,
-    int*                          xDest, // x-coord of destination upper-left corner
-    int*                          yDest, // y-coord of destination upper-left corner
-    int*                          widthDest,   // width of destination rectangle
-    int*                          heightDest   // height of destination rectangle
+static void fix_rect_0size(PIMAGE imgDest,      //
+    int*                          xDest,      // x-coord of destination upper-left corner
+    int*                          yDest,      // y-coord of destination upper-left corner
+    int*                          widthDest,  // width of destination rectangle
+    int*                          heightDest  // height of destination rectangle
 )
 {
-    struct viewporttype _vpt = {0, 0, pdest->m_width, pdest->m_height};
+    struct viewporttype _vpt = {0, 0, imgDest->m_width, imgDest->m_height};
     if (*widthDest == 0) {
-        *widthDest = pdest->m_width;
+        *widthDest = imgDest->m_width;
     }
     if (*heightDest == 0) {
-        *heightDest = pdest->m_height;
+        *heightDest = imgDest->m_height;
     }
     if (*xDest < _vpt.left) {
         int dx         = _vpt.left - *xDest;
@@ -1465,24 +1465,24 @@ int IMAGE::imagefilter_blurring(
     return grOk;
 }
 
-int IMAGE::putimage_rotate(PIMAGE imgtexture, int xDest, int yDest, float centerx, float centery,
+int IMAGE::putimage_rotate(PIMAGE imgTexture, int xDest, int yDest, float centerx, float centery,
     float radian,
     int   btransparent, // transparent (1) or not (0)
     int   alpha,        // in range[0, 256], alpha== -1 means no alpha
     int   smooth)
 {
     return ege::putimage_rotate(
-        this, imgtexture, xDest, yDest, centerx, centery, radian, btransparent, alpha, smooth);
+        this, imgTexture, xDest, yDest, centerx, centery, radian, btransparent, alpha, smooth);
 }
 
-int IMAGE::putimage_rotatezoom(PIMAGE imgtexture, int xDest, int yDest, float centerx, float centery,
+int IMAGE::putimage_rotatezoom(PIMAGE imgTexture, int xDest, int yDest, float centerx, float centery,
     float radian, float zoom,
     int btransparent, // transparent (1) or not (0)
     int alpha,        // in range[0, 256], alpha== -1 means no alpha
     int smooth)
 {
     return ege::putimage_rotatezoom(
-        this, imgtexture, xDest, yDest, centerx, centery, radian, zoom, btransparent, alpha, smooth);
+        this, imgTexture, xDest, yDest, centerx, centery, radian, zoom, btransparent, alpha, smooth);
 }
 
 #define BILINEAR_INTERPOLATION(s, LT, RT, LB, RB, x, y)                                     \
@@ -2405,13 +2405,13 @@ static void draw_flat_trangle_alpha_s(PIMAGE dc_dest, const struct trangle2d* dt
     }
 }
 
-int putimage_trangle(PIMAGE imgDest, PCIMAGE imgtexture,
+int putimage_trangle(PIMAGE imgDest, PCIMAGE imgTexture,
     const struct trangle2d* dt, // dest trangle, original
     const struct trangle2d* tt, // textture trangle uv 0.0 - 1.0
     bool transparent, int alpha, bool smooth)
 {
     PIMAGE  dc_dest = imgDest;
-    PCIMAGE dc_src  = imgtexture;
+    PCIMAGE dc_src  = imgTexture;
 
     if (dc_dest) {
         struct trangle2d _dt = *dt;
@@ -2441,14 +2441,14 @@ int putimage_trangle(PIMAGE imgDest, PCIMAGE imgtexture,
     return grOk;
 }
 
-int putimage_rotate(PIMAGE imgDest, PCIMAGE imgtexture, int xDest, int yDest, float centerx,
+int putimage_rotate(PIMAGE imgDest, PCIMAGE imgTexture, int xDest, int yDest, float centerx,
     float centery, float radian,
     bool transparent,
     int alpha,        // in range[0, 256], alpha==256 means no alpha
     bool smooth)
 {
     PIMAGE  dc_dest = CONVERT_IMAGE(imgDest);
-    PCIMAGE dc_src  = imgtexture;
+    PCIMAGE dc_src  = imgTexture;
 
     if (dc_dest) {
         struct trangle2d _tt[2];
@@ -2478,21 +2478,21 @@ int putimage_rotate(PIMAGE imgDest, PCIMAGE imgtexture, int xDest, int yDest, fl
             }
         }
 
-        putimage_trangle(dc_dest, imgtexture, &_dt[0], &_tt[0], transparent, alpha, smooth);
-        putimage_trangle(dc_dest, imgtexture, &_dt[1], &_tt[1], transparent, alpha, smooth);
+        putimage_trangle(dc_dest, imgTexture, &_dt[0], &_tt[0], transparent, alpha, smooth);
+        putimage_trangle(dc_dest, imgTexture, &_dt[1], &_tt[1], transparent, alpha, smooth);
     }
     CONVERT_IMAGE_END;
     return grOk;
 }
 
-int putimage_rotatezoom(PIMAGE imgDest, PCIMAGE imgtexture, int xDest, int yDest, float centerx,
+int putimage_rotatezoom(PIMAGE imgDest, PCIMAGE imgTexture, int xDest, int yDest, float centerx,
     float centery, float radian, float zoom,
     bool transparent, // transparent (1) or not (0)
     int alpha,        // in range[0, 256], alpha==256 means no alpha
     bool smooth)
 {
     PIMAGE  dc_dest = CONVERT_IMAGE(imgDest);
-    PCIMAGE dc_src  = imgtexture;
+    PCIMAGE dc_src  = imgTexture;
     if (dc_dest) {
         struct trangle2d _tt[2];
         struct trangle2d _dt[2];
@@ -2521,8 +2521,8 @@ int putimage_rotatezoom(PIMAGE imgDest, PCIMAGE imgtexture, int xDest, int yDest
             }
         }
 
-        putimage_trangle(dc_dest, imgtexture, &_dt[0], &_tt[0], transparent, alpha, smooth);
-        putimage_trangle(dc_dest, imgtexture, &_dt[1], &_tt[1], transparent, alpha, smooth);
+        putimage_trangle(dc_dest, imgTexture, &_dt[0], &_tt[0], transparent, alpha, smooth);
+        putimage_trangle(dc_dest, imgTexture, &_dt[1], &_tt[1], transparent, alpha, smooth);
     }
     CONVERT_IMAGE_END;
     return grOk;
@@ -2760,15 +2760,15 @@ void putimage(int xDest, int yDest, int widthDest, int heightDest, PCIMAGE pSrcI
     pSrcImg->putimage(NULL, xDest, yDest, widthDest, heightDest, xSrc, ySrc, srcWidth, srcHeight, dwRop);
 }
 
-int putimage_transparent(PIMAGE imgDest,       // handle to dest
-    PCIMAGE                     imgSrc,        // handle to source
-    int                         xDest,  // x-coord of destination upper-left corner
-    int                         yDest,  // y-coord of destination upper-left corner
-    color_t                     transparentColor, // color to make transparent
-    int                         xSrc,   // x-coord of source upper-left corner
-    int                         ySrc,   // y-coord of source upper-left corner
-    int                         widthSrc,     // width of source rectangle
-    int                         heightSrc     // height of source rectangle
+int putimage_transparent(PIMAGE imgDest,            // handle to dest
+    PCIMAGE                     imgSrc,             // handle to source
+    int                         xDest,              // x-coord of destination upper-left corner
+    int                         yDest,              // y-coord of destination upper-left corner
+    color_t                     transparentColor,   // color to make transparent
+    int                         xSrc,               // x-coord of source upper-left corner
+    int                         ySrc,               // y-coord of source upper-left corner
+    int                         widthSrc,           // width of source rectangle
+    int                         heightSrc           // height of source rectangle
 )
 {
     imgSrc = CONVERT_IMAGE_CONST(imgSrc);
@@ -2776,13 +2776,13 @@ int putimage_transparent(PIMAGE imgDest,       // handle to dest
         imgDest, xDest, yDest, transparentColor, xSrc, ySrc, widthSrc, heightSrc);
 }
 
-int putimage_alphablend(PIMAGE imgDest,      // handle to dest
-    PCIMAGE                    imgSrc,       // handle to source
-    int                        xDest, // x-coord of destination upper-left corner
-    int                        yDest, // y-coord of destination upper-left corner
-    unsigned char              alpha,        // alpha
-    int                        xSrc,  // x-coord of source upper-left corner
-    int                        ySrc,  // y-coord of source upper-left corner
+int putimage_alphablend(PIMAGE imgDest,     // handle to dest
+    PCIMAGE                    imgSrc,      // handle to source
+    int                        xDest,       // x-coord of destination upper-left corner
+    int                        yDest,       // y-coord of destination upper-left corner
+    unsigned char              alpha,       // alpha
+    int                        xSrc,        // x-coord of source upper-left corner
+    int                        ySrc,        // y-coord of source upper-left corner
     int                        widthSrc,    // width of source rectangle
     int                        heightSrc    // height of source rectangle
 )
@@ -2792,16 +2792,16 @@ int putimage_alphablend(PIMAGE imgDest,      // handle to dest
         imgDest, xDest, yDest, alpha, xSrc, ySrc, widthSrc, heightSrc);
 }
 
-int putimage_alphatransparent(PIMAGE imgDest,       // handle to dest
-    PCIMAGE                          imgSrc,        // handle to source
-    int                              xDest,  // x-coord of destination upper-left corner
-    int                              yDest,  // y-coord of destination upper-left corner
-    color_t                          transparentColor, // color to make transparent
-    unsigned char                    alpha,         // alpha
-    int                              xSrc,   // x-coord of source upper-left corner
-    int                              ySrc,   // y-coord of source upper-left corner
-    int                              widthSrc,     // width of source rectangle
-    int                              heightSrc     // height of source rectangle
+int putimage_alphatransparent(PIMAGE imgDest,           // handle to dest
+    PCIMAGE                          imgSrc,            // handle to source
+    int                              xDest,             // x-coord of destination upper-left corner
+    int                              yDest,             // y-coord of destination upper-left corner
+    color_t                          transparentColor,  // color to make transparent
+    unsigned char                    alpha,             // alpha
+    int                              xSrc,              // x-coord of source upper-left corner
+    int                              ySrc,              // y-coord of source upper-left corner
+    int                              widthSrc,          // width of source rectangle
+    int                              heightSrc          // height of source rectangle
 )
 {
     imgSrc = CONVERT_IMAGE_CONST(imgSrc);

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -2809,14 +2809,14 @@ int putimage_alphatransparent(PIMAGE imgDest,       // handle to dest
         imgDest, xDest, yDest, transparentColor, alpha, xSrc, ySrc, widthSrc, heightSrc);
 }
 
-int putimage_withalpha(PIMAGE imgDest,      // handle to dest
-    PCIMAGE                   imgSrc,       // handle to source
-    int                       xDest, // x-coord of destination upper-left corner
-    int                       yDest, // y-coord of destination upper-left corner
-    int                       xSrc,  // x-coord of source upper-left corner
-    int                       ySrc,  // y-coord of source upper-left corner
-    int                       widthSrc,    // width of source rectangle
-    int                       heightSrc    // height of source rectangle
+int putimage_withalpha(PIMAGE imgDest,  // handle to dest
+    PCIMAGE                   imgSrc,   // handle to source
+    int                       xDest,    // x-coord of destination upper-left corner
+    int                       yDest,    // y-coord of destination upper-left corner
+    int                       xSrc,     // x-coord of source upper-left corner
+    int                       ySrc,     // y-coord of source upper-left corner
+    int                       widthSrc, // width of source rectangle
+    int                       heightSrc // height of source rectangle
 )
 {
     imgSrc = CONVERT_IMAGE_CONST(imgSrc);
@@ -2842,15 +2842,15 @@ int EGEAPI putimage_withalpha(PIMAGE imgDest,    // handle to dest
         imgDest, xDest, yDest, widthDest, heightDest, xSrc, ySrc, widthSrc, heightSrc, smooth);
 }
 
-int putimage_alphafilter(PIMAGE imgDest,      // handle to dest
-    PCIMAGE                     imgSrc,       // handle to source
-    int                         xDest, // x-coord of destination upper-left corner
-    int                         yDest, // y-coord of destination upper-left corner
-    PCIMAGE                     imgAlpha,     // alpha
-    int                         xSrc,  // x-coord of source upper-left corner
-    int                         ySrc,  // y-coord of source upper-left corner
-    int                         widthSrc,    // width of source rectangle
-    int                         heightSrc    // height of source rectangle
+int putimage_alphafilter(PIMAGE imgDest,    // handle to dest
+    PCIMAGE                     imgSrc,     // handle to source
+    int                         xDest,      // x-coord of destination upper-left corner
+    int                         yDest,      // y-coord of destination upper-left corner
+    PCIMAGE                     imgAlpha,   // alpha
+    int                         xSrc,       // x-coord of source upper-left corner
+    int                         ySrc,       // y-coord of source upper-left corner
+    int                         widthSrc,   // width of source rectangle
+    int                         heightSrc   // height of source rectangle
 )
 {
     imgSrc = CONVERT_IMAGE_CONST(imgSrc);

--- a/src/image.h
+++ b/src/image.h
@@ -107,35 +107,44 @@ public:
 
     int getpngimg(FILE* fp);
 
-    int putimage_transparent(PIMAGE imgDest,         // handle to dest
-        int                         xDest,    // x-coord of destination upper-left corner
-        int                         yDest,    // y-coord of destination upper-left corner
-        color_t                     transparentColor,   // color to make transparent
-        int                         xSrc = 0, // x-coord of source upper-left corner
-        int                         ySrc = 0, // y-coord of source upper-left corner
-        int                         widthSrc   = 0, // width of source rectangle
-        int                         heightSrc  = 0  // height of source rectangle
+    int putimage_transparent(PIMAGE imgDest,                // handle to dest
+        int                         xDest,                  // x-coord of destination upper-left corner
+        int                         yDest,                  // y-coord of destination upper-left corner
+        color_t                     transparentColor,       // color to make transparent
+        int                         xSrc = 0,               // x-coord of source upper-left corner
+        int                         ySrc = 0,               // y-coord of source upper-left corner
+        int                         widthSrc   = 0,         // width of source rectangle
+        int                         heightSrc  = 0          // height of source rectangle
     ) const;
 
-    int putimage_alphablend(PIMAGE imgDest,         // handle to dest
-        int                        xDest,    // x-coord of destination upper-left corner
-        int                        yDest,    // y-coord of destination upper-left corner
-        unsigned char              alpha,           // alpha
-        int                        xSrc = 0, // x-coord of source upper-left corner
-        int                        ySrc = 0, // y-coord of source upper-left corner
-        int                        widthSrc   = 0, // width of source rectangle
-        int                        heightSrc  = 0  // height of source rectangle
+    int putimage_alphablend(PIMAGE imgDest,                 // handle to dest
+        int                        xDest,                   // x-coord of destination upper-left corner
+        int                        yDest,                   // y-coord of destination upper-left corner
+        unsigned char              alpha,                   // alpha
+        int                        xSrc = 0,                // x-coord of source upper-left corner
+        int                        ySrc = 0,                // y-coord of source upper-left corner
+        int                        widthSrc   = 0,          // width of source rectangle
+        int                        heightSrc  = 0           // height of source rectangle
     ) const;
 
-    int putimage_alphatransparent(PIMAGE imgDest,         // handle to dest
-        int                              xDest,    // x-coord of destination upper-left corner
-        int                              yDest,    // y-coord of destination upper-left corner
-        color_t                          transparentColor,   // color to make transparent
-        unsigned char                    alpha,           // alpha
-        int                              xSrc = 0, // x-coord of source upper-left corner
-        int                              ySrc = 0, // y-coord of source upper-left corner
-        int                              widthSrc   = 0, // width of source rectangle
-        int                              heightSrc  = 0  // height of source rectangle
+    int putimage_alphatransparent(PIMAGE imgDest,           // handle to dest
+        int                              xDest,             // x-coord of destination upper-left corner
+        int                              yDest,             // y-coord of destination upper-left corner
+        color_t                          transparentColor,  // color to make transparent
+        unsigned char                    alpha,             // alpha
+        int                              xSrc = 0,          // x-coord of source upper-left corner
+        int                              ySrc = 0,          // y-coord of source upper-left corner
+        int                              widthSrc   = 0,    // width of source rectangle
+        int                              heightSrc  = 0     // height of source rectangle
+    ) const;
+
+    int putimage_withalpha(PIMAGE imgDest,          // handle to dest
+        int                       xDest,            // x-coord of destination upper-left corner
+        int                       yDest,            // y-coord of destination upper-left corner
+        int                       xSrc = 0,         // x-coord of source upper-left corner
+        int                       ySrc = 0,         // y-coord of source upper-left corner
+        int                       widthSrc   = 0,   // width of source rectangle
+        int                       heightSrc  = 0    // height of source rectangle
     ) const;
 
     int putimage_withalpha(PIMAGE imgDest,         // handle to dest
@@ -147,24 +156,24 @@ public:
         int                       heightSrc  = 0  // height of source rectangle
     ) const;
 
-    int putimage_withalpha(PIMAGE imgDest,     // handle to dest
-        int                       xDest,       // x-coord of destination upper-left corner
-        int                       yDest,       // y-coord of destination upper-left corner
-        int                       widthDest,   // width of destination rectangle
-        int                       heightDest,  // height of destination rectangle
-        int                       xSrc,        // x-coord of source upper-left corner
-        int                       ySrc,        // y-coord of source upper-left corner
-        int                       widthSrc,    // width of source rectangle
-        int                       heightSrc,   // height of source rectangle
+    int putimage_withalpha(PIMAGE imgDest,          // handle to dest
+        int                       xDest,            // x-coord of destination upper-left corner
+        int                       yDest,            // y-coord of destination upper-left corner
+        int                       widthDest,        // width of destination rectangle
+        int                       heightDest,       // height of destination rectangle
+        int                       xSrc,             // x-coord of source upper-left corner
+        int                       ySrc,             // y-coord of source upper-left corner
+        int                       widthSrc,         // width of source rectangle
+        int                       heightSrc,        // height of source rectangle
         bool                      smooth = false
     ) const;
 
-    int putimage_alphafilter(PIMAGE imgDest,         // handle to dest
-        int                         xDest,    // x-coord of destination upper-left corner
-        int                         yDest,    // y-coord of destination upper-left corner
-        PCIMAGE                     imgAlpha,        // alpha
-        int                         xSrc = 0, // x-coord of source upper-left corner
-        int                         ySrc = 0, // y-coord of source upper-left corner
+    int putimage_alphafilter(PIMAGE imgDest,        // handle to dest
+        int                         xDest,          // x-coord of destination upper-left corner
+        int                         yDest,          // y-coord of destination upper-left corner
+        PCIMAGE                     imgAlpha,       // alpha
+        int                         xSrc = 0,       // x-coord of source upper-left corner
+        int                         ySrc = 0,       // y-coord of source upper-left corner
         int                         widthSrc   = 0, // width of source rectangle
         int                         heightSrc  = 0  // height of source rectangle
     ) const;

--- a/src/image.h
+++ b/src/image.h
@@ -147,15 +147,6 @@ public:
         int                       heightSrc  = 0    // height of source rectangle
     ) const;
 
-    int putimage_withalpha(PIMAGE imgDest,         // handle to dest
-        int                       xDest,    // x-coord of destination upper-left corner
-        int                       yDest,    // y-coord of destination upper-left corner
-        int                       xSrc = 0, // x-coord of source upper-left corner
-        int                       ySrc = 0, // y-coord of source upper-left corner
-        int                       widthSrc   = 0, // width of source rectangle
-        int                       heightSrc  = 0  // height of source rectangle
-    ) const;
-
     int putimage_withalpha(PIMAGE imgDest,          // handle to dest
         int                       xDest,            // x-coord of destination upper-left corner
         int                       yDest,            // y-coord of destination upper-left corner

--- a/src/type.h
+++ b/src/type.h
@@ -47,6 +47,7 @@ typedef long POINTER_SIZE;
 namespace ege
 {
 
+typedef unsigned char byte;
 
 struct Point
 {


### PR DESCRIPTION
修改为常用的 AlphaBlend 算法。公式为：
A = A(dst)  + alpha * (1.0    - A(dst));
R = R(dst)  + alpha * (R(src) - R(dst));
G = G(dst) + alpha * (G(src) - G(dst));
B = B(dst)  + alpha *  (B(src) - B(dst));

修改后可完成图层绘图功能。缺点是耗时增加 2~3 倍 (MSVC 优化不如 GCC)。