### PR TITLE
fix: 解决矩形区域输出文本无法正确对齐的问题

### DIFF
--- a/include/ege.h
+++ b/include/ege.h
@@ -428,7 +428,7 @@ enum text_just
     RIGHT_TEXT           = 2,
 
     BOTTOM_TEXT          = 0,
-    /* CENTER_TEXT       = 1,  already defined above */
+/*  CENTER_TEXT          = 1,  already defined above */
     TOP_TEXT             = 2
 };
 
@@ -1057,31 +1057,31 @@ void EGEAPI delay_jfps(double fps);
 double EGEAPI fclock();
 
 
-void EGEAPI outtext(const char*  text, PIMAGE pimg = NULL);
+void EGEAPI outtext(const char*    text, PIMAGE pimg = NULL);
 void EGEAPI outtext(const wchar_t* text, PIMAGE pimg = NULL);
-void EGEAPI outtext(char  c, PIMAGE pimg = NULL);
+void EGEAPI outtext(char    c, PIMAGE pimg = NULL);
 void EGEAPI outtext(wchar_t c, PIMAGE pimg = NULL);
 
-void EGEAPI outtextxy(int x, int y, const char*  text, PIMAGE pimg = NULL);
+void EGEAPI outtextxy(int x, int y, const char*    text, PIMAGE pimg = NULL);
 void EGEAPI outtextxy(int x, int y, const wchar_t* text, PIMAGE pimg = NULL);
-void EGEAPI outtextxy(int x, int y, char c, PIMAGE pimg = NULL);
+void EGEAPI outtextxy(int x, int y, char    c, PIMAGE pimg = NULL);
 void EGEAPI outtextxy(int x, int y, wchar_t c, PIMAGE pimg = NULL);
-void EGEAPI xyprintf (int x, int y, const char*  format, ...);
+void EGEAPI xyprintf (int x, int y, const char*    format, ...);
 void EGEAPI xyprintf (int x, int y, const wchar_t* format, ...);
 
-void EGEAPI outtextrect(int x, int y, int w, int h, const char*  text, PIMAGE pimg = NULL);
+void EGEAPI outtextrect(int x, int y, int w, int h, const char*    text, PIMAGE pimg = NULL);
 void EGEAPI outtextrect(int x, int y, int w, int h, const wchar_t* text, PIMAGE pimg = NULL);
-void EGEAPI rectprintf (int x, int y, int w, int h, const char*  format, ...);
+void EGEAPI rectprintf (int x, int y, int w, int h, const char*    format, ...);
 void EGEAPI rectprintf (int x, int y, int w, int h, const wchar_t* format, ...);
 
-int  EGEAPI textwidth(const char*  text, PIMAGE pimg = NULL);
+int  EGEAPI textwidth(const char*    text, PIMAGE pimg = NULL);
 int  EGEAPI textwidth(const wchar_t* text, PIMAGE pimg = NULL);
-int  EGEAPI textwidth(char  c, PIMAGE pimg = NULL);
+int  EGEAPI textwidth(char    c, PIMAGE pimg = NULL);
 int  EGEAPI textwidth(wchar_t c, PIMAGE pimg = NULL);
 
-int  EGEAPI textheight(const char*  text, PIMAGE pimg = NULL);
+int  EGEAPI textheight(const char*    text, PIMAGE pimg = NULL);
 int  EGEAPI textheight(const wchar_t* text, PIMAGE pimg = NULL);
-int  EGEAPI textheight(char  c, PIMAGE pimg = NULL);
+int  EGEAPI textheight(char    c, PIMAGE pimg = NULL);
 int  EGEAPI textheight(wchar_t c, PIMAGE pimg = NULL);
 
 void EGEAPI settextjustify(int horiz, int vert, PIMAGE pimg = NULL);


### PR DESCRIPTION
- rectprintf 内部使用的 DrawText()，这个函数和 TextOut() 使用的同一个对齐设置，而是通过其参数来控制文本对齐方式。

- DrawText() 内部在输出多行文本时并不支持垂直方向对齐，但是给出了输出区域的宽高，因此可以通过设置偏移来达到垂直方向对齐的目的。
- 但是裁剪只会对超出区域末尾的文本进行，通过偏移的方式虽然达到了垂直对齐的目的，但是改变了原本的输出区域，造成裁剪不正确。如果文本是底部对齐且行数超出范围，往上偏移之后会使得顶部文本超出原本的矩形区域。这个可以通过设置裁剪区域来解决，求出矩形区域与原本裁剪区域的交集作为新的裁剪区域，设置后再恢复恢复回原来的裁剪区域。
