### PR TITLE
adjust: 调整文本垂直对齐方式的枚举值

### DIFF
--- a/include/ege.h
+++ b/include/ege.h
@@ -427,9 +427,9 @@ enum text_just
     CENTER_TEXT          = 1,
     RIGHT_TEXT           = 2,
 
-    BOTTOM_TEXT          = 0,
+    TOP_TEXT             = 0,
     /* CENTER_TEXT       = 1,  already defined above */
-    TOP_TEXT             = 2
+    BOTTOM_TEXT          = 2
 };
 
 /* Line styles for get/setlinestyle */


### PR DESCRIPTION
默认的文本对齐方式应该是顶部对齐、左对齐，底层也是如此。因此 LEFT_TEXT 和 TOP_TEXT 的枚举值应设置为 0.