### PR TITLE
fix: 修复调整窗口大小时，GDI+ 裁剪区域错误的问题

### DIFF
--- a/src/egegapi.cpp
+++ b/src/egegapi.cpp
@@ -1414,6 +1414,15 @@ void setviewport(int left, int top, int right, int bottom, int clip, PIMAGE pimg
     SelectClipRgn(img->m_hDC, rgn);
     DeleteObject(rgn);
 
+    Gdiplus::Graphics* graphics = img->getGraphics();
+    if (img->m_vpt.clipflag) {
+        const viewporttype& viewport = img->m_vpt;
+        Gdiplus::Rect clipRect(viewport.left, viewport.top, viewport.right - viewport.left, viewport.bottom - viewport.top);
+        graphics->SetClip(clipRect);
+    } else {
+        graphics->ResetClip();
+    }
+
     // OffsetViewportOrgEx(img->m_hDC, img->m_vpt.left, img->m_vpt.top, NULL);
     SetViewportOrgEx(img->m_hDC, img->m_vpt.left, img->m_vpt.top, NULL);
 

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -307,6 +307,8 @@ int IMAGE::resize_f(int width, int height)
     m_height  = height;
     m_pBuffer = bmp_buf;
 
+    SelectClipRgn(this->m_hDC, NULL);
+
     // BITMAP 更换后需重新创建 Graphics 对象(否则会在已销毁的 old_bitmap 上绘制，引发异常)
     if (m_graphics != NULL) {
         Gdiplus::Graphics* newGraphics = recreateGdiplusGraphics(m_hDC, m_graphics);


### PR DESCRIPTION
通过设置了裁剪区域的 HDC 创建的 Graphics 后续无法再此区域外绘制，调整 Graphics 的裁剪区域也不行，创建前需要先取消 SelectClipRgn() 取消裁剪。