### PR TITLE
feat: 线条颜色和文本颜色可单独设置，setcolor() 前景色则同时设置线条颜色和文本颜色

### DIFF
--- a/include/ege.h
+++ b/include/ege.h
@@ -875,13 +875,17 @@ void EGEAPI setwritemode(int mode, PIMAGE pimg = NULL);
 //void EGEAPI graphdefaults(PIMAGE pimg = NULL);                  // ###
 
 color_t EGEAPI getcolor      (PCIMAGE pimg = NULL);
+color_t EGEAPI getlinecolor  (PCIMAGE pimg = NULL);
 color_t EGEAPI getfillcolor  (PCIMAGE pimg = NULL);
 color_t EGEAPI getbkcolor    (PCIMAGE pimg = NULL);
+color_t EGEAPI gettextcolor  (PCIMAGE pimg = NULL);
 
 void    EGEAPI setcolor      (color_t color, PIMAGE pimg = NULL);
+void    EGEAPI setlinecolor  (color_t color, PIMAGE pimg = NULL);
 void    EGEAPI setfillcolor  (color_t color, PIMAGE pimg = NULL);
 void    EGEAPI setbkcolor    (color_t color, PIMAGE pimg = NULL);
 void    EGEAPI setbkcolor_f  (color_t color, PIMAGE pimg = NULL);
+void    EGEAPI settextcolor  (color_t color, PIMAGE pimg = NULL);
 void    EGEAPI setfontbkcolor(color_t color, PIMAGE pimg = NULL);
 
 void    EGEAPI setbkmode(int bkMode, PIMAGE pimg = NULL);

--- a/src/egegapi.cpp
+++ b/src/egegapi.cpp
@@ -481,18 +481,16 @@ void rectangle(int left, int top, int right, int bottom, PIMAGE pimg)
 
 color_t getcolor(PCIMAGE pimg)
 {
+    return getlinecolor(pimg);
+}
+
+color_t getlinecolor(PCIMAGE pimg)
+{
     PCIMAGE img = CONVERT_IMAGE_CONST(pimg);
 
     if (img && img->m_hDC) {
         CONVERT_IMAGE_END;
-        return img->m_color;
-        /*
-        HPEN hpen_c = (HPEN)GetCurrentObject(img->m_hDC, OBJ_PEN);
-        LOGPEN logPen;
-        GetObject(hpen_c, sizeof(logPen), &logPen);
-        CONVERT_IMAGE_END;
-        return logPen.lopnColor;
-        // */
+        return img->m_linecolor;
     }
     CONVERT_IMAGE_END;
     return 0xFFFFFFFF;
@@ -534,7 +532,7 @@ static int upattern2array(unsigned short pattern, DWORD style[])
 static void update_pen(PIMAGE img)
 {
     LOGBRUSH lbr;
-    lbr.lbColor = ARGBTOZBGR(img->m_color);
+    lbr.lbColor = ARGBTOZBGR(img->m_linecolor);
     lbr.lbStyle = BS_SOLID;
     lbr.lbHatch = 0;
 
@@ -560,7 +558,7 @@ static void update_pen(PIMAGE img)
     // why update pen not in IMAGE???
 #ifdef EGE_GDIPLUS
     Gdiplus::Pen* pen = img->getPen();
-    pen->SetColor(img->m_color);
+    pen->SetColor(img->m_linecolor);
     pen->SetWidth(img->m_linewidth);
     pen->SetDashStyle(linestyle_to_dashstyle(img->m_linestyle.linestyle));
 #endif
@@ -568,15 +566,18 @@ static void update_pen(PIMAGE img)
 
 void setcolor(color_t color, PIMAGE pimg)
 {
-    PIMAGE img = CONVERT_IMAGE(pimg);
+    setlinecolor(color, pimg);
+    settextcolor(color, pimg);
+}
 
+void setlinecolor(color_t color, PIMAGE pimg)
+{
+    PIMAGE img = CONVERT_IMAGE_CONST(pimg);
     if (img && img->m_hDC) {
-        img->m_color = color;
-
+        img->m_linecolor = color;
         update_pen(img);
-        SetTextColor(img->m_hDC, ARGBTOZBGR(color));
     }
-    CONVERT_IMAGE_END;
+    CONVERT_IMAGE_END
 }
 
 void setfillcolor(color_t color, PIMAGE pimg)
@@ -609,10 +610,21 @@ color_t getbkcolor(PCIMAGE pimg)
 {
     PCIMAGE img = CONVERT_IMAGE_CONST(pimg);
 
-    CONVERT_IMAGE_END;
     if (img) {
         return img->m_bk_color;
     }
+    CONVERT_IMAGE_END;
+    return 0xFFFFFFFF;
+}
+
+color_t gettextcolor(PCIMAGE pimg)
+{
+    PCIMAGE img = CONVERT_IMAGE_CONST(pimg);
+
+    if (img) {
+        return img->m_textcolor;
+    }
+    CONVERT_IMAGE_END;
     return 0xFFFFFFFF;
 }
 
@@ -642,6 +654,17 @@ void setbkcolor_f(color_t color, PIMAGE pimg)
     if (img && img->m_hDC) {
         img->m_bk_color = color;
         SetBkColor(img->m_hDC, ARGBTOZBGR(color));
+    }
+    CONVERT_IMAGE_END;
+}
+
+void settextcolor(color_t color, PIMAGE pimg)
+{
+    PIMAGE img = CONVERT_IMAGE_CONST(pimg);
+
+    if (img && img->m_hDC) {
+        img->m_textcolor = color;
+        SetTextColor(img->m_hDC, ARGBTOZBGR(color));
     }
     CONVERT_IMAGE_END;
 }

--- a/src/font.cpp
+++ b/src/font.cpp
@@ -602,7 +602,7 @@ static void ege_drawtext_p(const wchar_t* textstring, float x, float y,  PIMAGE 
     // 	fprintf(stderr, "!font.IsAvailable(), hf: %p\n", hf);
     // }
     Gdiplus::PointF origin(x, y);
-    Gdiplus::SolidBrush brush(img->m_color);
+    Gdiplus::SolidBrush brush(img->m_textcolor);
 
     Gdiplus::StringFormat* format = Gdiplus::StringFormat::GenericTypographic()->Clone();
 

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -39,14 +39,15 @@ void IMAGE::reset()
     m_width     = 0;
     m_height    = 0;
     m_pBuffer   = NULL;
-    m_color     = 0;
+    m_linecolor     = 0;
     m_fillcolor = 0;
+    m_textcolor = 0;
+    m_bk_color  = 0;
     m_aa        = false;
     memset(&m_vpt, 0, sizeof(m_vpt));
     memset(&m_texttype, 0, sizeof(m_texttype));
     memset(&m_linestyle, 0, sizeof(m_linestyle));
     m_linewidth = 0.0f;
-    m_bk_color  = 0;
     m_texture   = NULL;
 #ifdef EGE_GDIPLUS
     m_graphics = NULL;
@@ -245,7 +246,7 @@ Gdiplus::Graphics* IMAGE::getGraphics()
 Gdiplus::Pen* IMAGE::getPen()
 {
     if (NULL == m_pen) {
-        m_pen = new Gdiplus::Pen(m_color, m_linewidth);
+        m_pen = new Gdiplus::Pen(m_linecolor, m_linewidth);
         m_pen->SetDashStyle(linestyle_to_dashstyle(m_linestyle.linestyle));
     }
     return m_pen;

--- a/src/image.h
+++ b/src/image.h
@@ -18,8 +18,10 @@ public:
     int     m_width;
     int     m_height;
     PDWORD  m_pBuffer;
-    color_t m_color;
+    color_t m_linecolor;
     color_t m_fillcolor;
+    color_t m_textcolor;
+    color_t m_bk_color;
 
 private:
 #ifdef EGE_GDIPLUS
@@ -39,7 +41,6 @@ public:
     textsettingstype m_texttype;
     linestyletype    m_linestyle;
     float            m_linewidth;
-    color_t          m_bk_color;
     void*            m_texture;
 
 private:


### PR DESCRIPTION
文本颜色通常很少改动，而线条颜色经常变换。如果文本颜色和线条颜色不相同，则绘图时需要频繁切换，如果忘记则出现颜色不正确。
GDI/GDI+ 这两个颜色是分开设置的，同时设置不利于颜色的控制，故增加 line color 和 text color，而原来的 setcolor() 含义是设置前景色，依然是同时控制两个颜色保持不变。getcolor() 返回的是 line color，在不单独设置的情况下和原来没有区别，如果两种颜色不同，则前景色以 line color 为准。