### PR TITLE
feat: 增加线帽设置

### DIFF
--- a/include/ege.h
+++ b/include/ege.h
@@ -673,6 +673,13 @@ struct linestyletype
     int             thickness;
 };
 
+enum linecaptype
+{
+    LINECAP_FLAT   = 0,
+    LINECAP_SQUARE,
+    LINECAP_ROUND,
+};
+
 typedef struct key_msg
 {
     int             key;
@@ -866,6 +873,10 @@ void EGEAPI window_setviewport(int  left, int  top, int  right, int  bottom);
 void EGEAPI getlinestyle(int* linestyle, unsigned short* pattern = NULL, int* thickness = NULL, PCIMAGE pimg = NULL);
 void EGEAPI setlinestyle(int  linestyle, unsigned short  pattern = 0,    int  thickness = 1,    PIMAGE pimg = NULL);
 void EGEAPI setlinewidth(float width, PIMAGE pimg = NULL);
+void EGEAPI setlinecap(linecaptype linecap, PIMAGE pimg = NULL);
+void EGEAPI setlinecap(linecaptype  startCap, linecaptype  endCap, PIMAGE pimg = NULL);
+void EGEAPI getlinecap(linecaptype* startCap, linecaptype* endCap, PIMAGE pimg = NULL);
+linecaptype EGEAPI getlinecap(PIMAGE pimg = NULL);
 
 //void getfillstyle(color_t *pcolor, int *ppattern = NULL, PIMAGE pimg = NULL);           // ###
 void EGEAPI setfillstyle(int pattern, color_t color, PIMAGE pimg = NULL);

--- a/src/ege_graph.h
+++ b/src/ege_graph.h
@@ -35,6 +35,8 @@ void gdipluinit();
 
 Gdiplus::Graphics* recreateGdiplusGraphics(HDC hdc, const Gdiplus::Graphics* oldGraphics);
 
+Gdiplus::LineCap convertToGdiplusLineCap(linecaptype linecap);
+
 int  swapbuffers();
 
 bool isinitialized();

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -47,8 +47,10 @@ void IMAGE::reset()
     memset(&m_vpt, 0, sizeof(m_vpt));
     memset(&m_texttype, 0, sizeof(m_texttype));
     memset(&m_linestyle, 0, sizeof(m_linestyle));
-    m_linewidth = 0.0f;
-    m_texture   = NULL;
+    m_linewidth    = 0.0f;
+    m_linestartcap = LINECAP_FLAT;
+    m_lineendcap   = LINECAP_FLAT;
+    m_texture      = NULL;
 #ifdef EGE_GDIPLUS
     m_graphics = NULL;
     m_pen      = NULL;

--- a/src/image.h
+++ b/src/image.h
@@ -41,6 +41,8 @@ public:
     textsettingstype m_texttype;
     linestyletype    m_linestyle;
     float            m_linewidth;
+    linecaptype      m_linestartcap;
+    linecaptype      m_lineendcap;
     void*            m_texture;
 
 private:


### PR DESCRIPTION
设置线帽 setlinecap
获取线帽样式 getlinecap
一共支持三种基础线帽样式，flat(平头), square(方头), round(圆头)

- GDI 仅支持线条两端使用同样的线帽，而 GDI+ 两端线帽可以不相同，故增加可分别设置两端线帽的 setlinecap 重载
- 默认为 flat，这个是大多数图形库所默认使用的线帽样式
- 上面三种是大多数图形库都支持的线帽样式，而 GDI+ 支持更多非基础线帽样式，暂时不加入，待后续考虑。