### PR TITLE
feat: 增加 ege_polyline 和 ege_polygon

### DIFF
--- a/include/ege.h
+++ b/include/ege.h
@@ -1023,6 +1023,8 @@ void EGEAPI ege_setalpha(int alpha, PIMAGE pimg = NULL);
 void EGEAPI ege_line(float x1, float y1, float x2, float y2, PIMAGE pimg = NULL);
 
 void EGEAPI ege_drawpoly       (int numOfPoints, const ege_point* points, PIMAGE pimg = NULL);
+void EGEAPI ege_polyline       (int numOfPoints, const ege_point* points, PIMAGE pimg = NULL);
+void EGEAPI ege_polygon        (int numOfPoints, const ege_point* points, PIMAGE pimg = NULL);
 void EGEAPI ege_fillpoly       (int numOfPoints, const ege_point* points, PIMAGE pimg = NULL);
 
 void EGEAPI ege_bezier         (int numOfPoints, const ege_point* points, PIMAGE pimg = NULL);

--- a/src/egegapi.cpp
+++ b/src/egegapi.cpp
@@ -1640,6 +1640,17 @@ void ege_line(float x1, float y1, float x2, float y2, PIMAGE pimg)
 
 void ege_drawpoly(int numOfPoints, const ege_point* points, PIMAGE pimg)
 {
+    /* 当首尾顶点为同一坐标时转成多边形，否则绘制折线 */
+    if (numOfPoints > 3 && points[0].x == points[numOfPoints-1].x
+        && points[0].y == points[numOfPoints-1].y) {
+        ege_polygon(numOfPoints - 1, points, pimg);
+    } else {
+        ege_polyline(numOfPoints, points, pimg);
+    }
+}
+
+void ege_polyline(int numOfPoints, const ege_point *points, PIMAGE pimg)
+{
     PIMAGE img = CONVERT_IMAGE(pimg);
     if (img) {
         if (img->m_linestyle.linestyle == PS_NULL) {
@@ -1647,14 +1658,21 @@ void ege_drawpoly(int numOfPoints, const ege_point* points, PIMAGE pimg)
         }
         Gdiplus::Graphics* graphics = img->getGraphics();
         Gdiplus::Pen* pen = img->getPen();
+        graphics->DrawLines(pen, (const Gdiplus::PointF*)points, numOfPoints);
+    }
+    CONVERT_IMAGE_END;
+}
 
-        /* 当首尾顶点为同一坐标时转成多边形，否则绘制折线 */
-        if (numOfPoints > 3 && points[0].x == points[numOfPoints-1].x
-            && points[0].y == points[numOfPoints-1].y) {
-            graphics->DrawPolygon(pen, (const Gdiplus::PointF*)points, numOfPoints - 1);
-        } else {
-            graphics->DrawLines(pen, (const Gdiplus::PointF*)points, numOfPoints);
+void ege_polygon(int numOfPoints, const ege_point *points, PIMAGE pimg)
+{
+    PIMAGE img = CONVERT_IMAGE(pimg);
+    if (img) {
+        if (img->m_linestyle.linestyle == PS_NULL) {
+            return;
         }
+        Gdiplus::Graphics* graphics = img->getGraphics();
+        Gdiplus::Pen* pen = img->getPen();
+        graphics->DrawPolygon(pen, (const Gdiplus::PointF*)points, numOfPoints);
     }
     CONVERT_IMAGE_END;
 }


### PR DESCRIPTION
ege_drawpoly 可同时绘制折线和多边形，首尾不相连时绘制折线，首尾相连时绘制多边形。多边形需要多创建一个冗余的点，并且有线帽和连接点样式的缘故，即使首尾相连，用户并不一定是想绘制多边形。因为将多边形和折线这两个绘图分离。