### PR TITLE
Fix: 修复调用 setviewport 后GDI+绘图坐标系原点未修改的问题

### DIFF
--- a/src/egegapi.cpp
+++ b/src/egegapi.cpp
@@ -1589,7 +1589,9 @@ void setviewport(int left, int top, int right, int bottom, int clip, PIMAGE pimg
         graphics->ResetClip();
     }
 
-    // OffsetViewportOrgEx(img->m_hDC, img->m_vpt.left, img->m_vpt.top, NULL);
+    graphics->ResetTransform();
+    graphics->TranslateTransform(img->m_vpt.left, img->m_vpt.top);
+
     SetViewportOrgEx(img->m_hDC, img->m_vpt.left, img->m_vpt.top, NULL);
     MoveToEx(img->m_hDC, 0, 0, NULL);
 


### PR DESCRIPTION
具体为重置坐标变换，坐标原点移动至视口左上角