### PR TITLE
Fix: 修复 keystate 在打开对话框后失效的问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 
 /build
 /temp
+/out

--- a/src/keyboard.cpp
+++ b/src/keyboard.cpp
@@ -229,10 +229,7 @@ int keystate(int key)
     if (key < 0 || key >= MAX_KEY_VCODE) {
         return -1;
     }
-    SHORT s = GetKeyState(key);
-    if (((USHORT)s & 0x8000) == 0) {
-        pg->keystatemap[key] = 0;
-    }
+
     return pg->keystatemap[key];
 }
 


### PR DESCRIPTION
使用 GetOpenFileName 等打开对话框后，keystate 失效，但按键消息正常。原因是 GetKeyState 是通过处理按键消息来判断按键状态，需要在消息队列的窗口线程中使用。（如果在其它线程，猜测目前的底层实现是会获取最新创建的一个窗口线程的按键状态，因此一开始未打开对话框时是正常的。）。
