### PR TITLE
Perf:  提高默认样式的直线的绘制速度

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vs/
+.history
 *.tlog
 *.obj
 [Dd]ebug/

--- a/src/egegapi.cpp
+++ b/src/egegapi.cpp
@@ -256,26 +256,44 @@ void moverel(int dx, int dy, PIMAGE pimg)
 void line(int x1, int y1, int x2, int y2, PIMAGE pimg)
 {
     PIMAGE img = CONVERT_IMAGE(pimg);
-    MoveToEx(img->m_hDC, x1, y1, NULL);
-    LineTo(img->m_hDC, x2, y2);
+    if (img) {
+        if (img->m_linestyle.linestyle != NULL_LINE) {
+            MoveToEx(img->m_hDC, x1, y1, NULL);
+            LineTo(img->m_hDC, x2, y2);
+        } else {
+            MoveToEx(img->m_hDC, x2, y2, NULL);
+        }
+    }
     CONVERT_IMAGE_END;
 }
 
 void linerel(int dx, int dy, PIMAGE pimg)
 {
     PIMAGE img = CONVERT_IMAGE(pimg);
-    POINT pt;
-    GetCurrentPositionEx(img->m_hDC, &pt);
-    dx += pt.x;
-    dy += pt.y;
-    LineTo(img->m_hDC, dx, dy);
+    if (img) {
+        POINT pt;
+        GetCurrentPositionEx(img->m_hDC, &pt);
+        dx += pt.x;
+        dy += pt.y;
+        if (img->m_linestyle.linestyle != NULL_LINE) {
+            LineTo(img->m_hDC, dx, dy);
+        } else {
+            MoveToEx(img->m_hDC, dx, dy, NULL);
+        }
+    }
     CONVERT_IMAGE_END;
 }
 
 void lineto(int x, int y, PIMAGE pimg)
 {
     PIMAGE img = CONVERT_IMAGE(pimg);
-    LineTo(img->m_hDC, x, y);
+    if (img) {
+        if (img->m_linestyle.linestyle != NULL_LINE) {
+            LineTo(img->m_hDC, x, y);
+        } else {
+            MoveToEx(img->m_hDC, x, y, NULL);
+        }
+    }
     CONVERT_IMAGE_END;
 }
 


### PR DESCRIPTION
GDI 有两种[笔类型](https://learn.microsoft.com/zh-cn/windows/win32/api/wingdi/nf-wingdi-extcreatepen)：`PS_GEOMETRIC` 和 `PS_COSMETIC`。
- PS_GEOMETRIC支持不同的线宽、线帽、线连接处样式等多种直线样式，但是绘制非常缓慢。
- PS_COSMETIC 仅支持线宽为1的直线，并且虚线类型有 bug，无法正确绘制，但是绘制较为快速 (线宽为 1 的情况下，速度是 PS_GEOMETRIC 的 4 倍 )

线宽为1时，线帽、线连接处样式等无区别，所以可以在直线线宽为 1 且线型为 SOLID_LINE 或 NULL_LINE 时使用 PS_COSMETIC 类型。

ege 内部自己实现的 line_f() 更为快速，速度大约是使用 PS_COSMETIC 笔类型时的 6 倍。缺点是，line_f() 只支持线宽为1的无线帽的实线，并且不支持设置二元光栅操作。