### PR TITLE
增加一键打包发布的脚本，减少发版负担。

### DIFF
--- a/tasks.sh
+++ b/tasks.sh
@@ -17,8 +17,17 @@ export BUILD_TARGET="xege" # 默认只构建 xege 静态库
 
 # 默认开Release模式
 export CMAKE_BUILD_TYPE="Release"
+
+if [[ -z "$WIN_CMAKE_BUILD_DEFINE" ]]; then
+    export WIN_CMAKE_BUILD_DEFINE=""
+fi
+
+if [[ -z "$CMAKE_CONFIG_DEFINE" ]]; then
+    export CMAKE_CONFIG_DEFINE=""
+fi
+
 function MY_CMAKE_BUILD_DEFINE() {
-    echo "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
+    echo "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} ${CMAKE_CONFIG_DEFINE}"
 }
 
 if ! command -v grealpath && command -v realpath; then
@@ -33,11 +42,13 @@ function isWindows() {
 }
 
 function loadCMakeProject() {
+
+    echo "Run cmake command: cmake "$(MY_CMAKE_BUILD_DEFINE)" .."
+
     if mkdir -p "$CMAKE_VS_DIR" &&
         cd "$CMAKE_VS_DIR" &&
-        cmake "$(MY_CMAKE_BUILD_DEFINE)" \
-            ..; then
-        echo "CMake Project Loaded!"
+        cmake $(MY_CMAKE_BUILD_DEFINE) ..; then
+        echo "CMake Project Loaded: MY_CMAKE_BUILD_DEFINE=$(MY_CMAKE_BUILD_DEFINE)"
     else
         echo "CMake Project Load Failed!"
         exit 1
@@ -59,7 +70,7 @@ function cmakeBuildAll() {
     if isWindows; then
 
         if [[ -n "$CMAKE_BUILD_TYPE" ]]; then
-            export WIN_CMAKE_BUILD_DEFINE="--config $CMAKE_BUILD_TYPE"
+            export WIN_CMAKE_BUILD_DEFINE="$WIN_CMAKE_BUILD_DEFINE --config $CMAKE_BUILD_TYPE"
         fi
 
         echo start: cmake.exe --build . --target "$BUILD_TARGET" $WIN_CMAKE_BUILD_DEFINE -- /m
@@ -121,6 +132,18 @@ while [[ $# > 0 ]]; do
     --target)
         echo "set build target to $2"
         export BUILD_TARGET="$2"
+        shift
+        shift
+        ;;
+    --toolset)
+        echo "set toolset to $2"
+        export CMAKE_CONFIG_DEFINE="$CMAKE_CONFIG_DEFINE -T $2"
+        shift
+        shift
+        ;;
+    --arch)
+        echo "set arch to $2"
+        export CMAKE_CONFIG_DEFINE="$CMAKE_CONFIG_DEFINE -A $2"
         shift
         shift
         ;;

--- a/utils/release.sh
+++ b/utils/release.sh
@@ -1,4 +1,112 @@
 #!/usr/bin/env bash
 
-cd "$(dirname "$0")"
-../tasks.sh --release --reload --target xege --build
+cd "$(dirname "$0")/.."
+
+EGE_DIR=$(pwd)
+
+if [[ $(uname -s) == "Darwin" ]] || [[ $(uname -s) == "Linux" ]]; then
+    # macos/linux
+    ./tasks.sh --clean --release --load --target xege --build
+
+else
+    # vs2022 - 64bit
+    if ./tasks.sh --clean --release --toolset v143 --arch x64 --target xege --load --build; then
+        mkdir -p Release/lib/vs2022/x64
+        cp -rf build/Release/*.lib Release/lib/vs2022/x64
+        git clean -ffdx build/Release
+        echo "Copy vs2022 x64 libs done: $(pwd)/Release/lib/vs2022/x64"
+    else
+        echo "Build vs2022 x64 failed!" >&2
+    fi
+
+    # vs2022 - 32bit
+    if ./tasks.sh --clean --release --toolset v143 --arch Win32 --target xege --load --build; then
+        mkdir -p Release/lib/vs2022/x86
+        cp -rf build/Release/*.lib Release/lib/vs2022/x86
+        git clean -ffdx build/Release
+        echo "Copy vs2022 x86 libs done: $(pwd)/Release/lib/vs2022/x86"
+    else
+        echo "Build vs2022 x86 failed!" >&2
+    fi
+
+    # vs2019 - 64bit
+    if ./tasks.sh --clean --release --target xege --toolset v142 --arch x64 --load --build; then
+        mkdir -p Release/lib/vs2019/x64
+        cp -rf build/Release/*.lib Release/lib/vs2019/x64
+        git clean -ffdx build/Release
+        echo "Copy vs2019 x64 libs done: $(pwd)/Release/lib/vs2019/x64"
+    else
+        echo "Build vs2019 x64 failed!" >&2
+    fi
+
+    # vs2019 - 32bit
+    if ./tasks.sh --clean --release --target xege --toolset v142 --arch Win32 --load --build; then
+        mkdir -p Release/lib/vs2019/x86
+        cp -rf build/Release/*.lib Release/lib/vs2019/x86
+        git clean -ffdx build/Release
+        echo "Copy vs2019 x86 libs done: $(pwd)/Release/lib/vs2019/x86"
+    else
+        echo "Build vs2019 x86 failed!" >&2
+    fi
+
+    # vs2017 - 64bit
+    if ./tasks.sh --clean --release --target xege --toolset v141 --arch x64 --load --build; then
+        mkdir -p Release/lib/vs2017/x64
+        cp -rf build/Release/*.lib Release/lib/vs2017/x64
+        git clean -ffdx build/Release
+        echo "Copy vs2017 x64 libs done: $(pwd)/Release/lib/vs2017/x64"
+    else
+        echo "Build vs2017 x64 failed!" >&2
+    fi
+
+    # vs2017 - 32bit
+    if ./tasks.sh --clean --release --target xege --toolset v141 --arch Win32 --load --build; then
+        mkdir -p Release/lib/vs2017/x86
+        cp -rf build/Release/*.lib Release/lib/vs2017/x86
+        git clean -ffdx build/Release
+        echo "Copy vs2017 x86 libs done: $(pwd)/Release/lib/vs2017/x86"
+    else
+        echo "Build vs2017 x86 failed!" >&2
+    fi
+
+    # vs2015 - 64bit
+
+    if ./tasks.sh --clean --release --target xege --toolset v140 --arch x64 --load --build; then
+        mkdir -p Release/lib/vs2015/amd64
+        cp -rf build/Release/*.lib Release/lib/vs2015/amd64
+        git clean -ffdx build/Release
+        echo "Copy vs2015 x64 libs done: $(pwd)/Release/lib/vs2015/amd64"
+    else
+        echo "Build vs2015 x64 failed!" >&2
+    fi
+
+    # vs2015 - 32bit
+    if ./tasks.sh --clean --release --target xege --toolset v140 --arch Win32 --load --build; then
+        mkdir -p Release/lib/vs2015
+        cp -rf build/Release/*.lib Release/lib/vs2015
+        git clean -ffdx build/Release
+        echo "Copy vs2015 x86 libs done: $(pwd)/Release/lib/vs2015"
+    else
+        echo "Build vs2015 x86 failed!" >&2
+    fi
+
+    # vs2010 - 64bit
+    if ./tasks.sh --clean --release --target xege --toolset v100 --arch x64 --load --build; then
+        mkdir -p Release/lib/vs2010/amd64
+        cp -rf build/Release/*.lib Release/lib/vs2010/amd64
+        git clean -ffdx build/Release
+        echo "Copy vs2010 x64 libs done: $(pwd)/Release/lib/vs2010/amd64"
+    else
+        echo "Build vs2010 x64 failed!" >&2
+    fi
+
+    # vs2010 - 32bit
+    if ./tasks.sh --clean --release --target xege --toolset v100 --arch Win32 --load --build; then
+        mkdir -p Release/lib/vs2010
+        cp -rf build/Release/*.lib Release/lib/vs2010
+        git clean -ffdx build/Release
+        echo "Copy vs2010 x86 libs done: $(pwd)/Release/lib/vs2010"
+    else
+        echo "Build vs2010 x86 failed!" >&2
+    fi
+fi


### PR DESCRIPTION
如题， 主要支持 vs2022/vs2019/vs2017/vs2015/vs2010, 其他平台可以后续再补充