### PR TITLE
[BUG修复]修正IMAGE::gentexture的会引发栈溢出的函数参数

### DIFF
--- a/src/image.cpp
+++ b/src/image.cpp
@@ -129,7 +129,7 @@ void IMAGE::gentexture(bool gen)
         }
     } else {
         if (m_texture != NULL) {
-            gentexture(true);
+            gentexture(false);
         }
         Gdiplus::Bitmap* bitmap =
             new Gdiplus::Bitmap(getwidth(), getheight(), getwidth() * 4, PixelFormat32bppARGB, (BYTE*)getbuffer());


### PR DESCRIPTION
函数参数应为false，原始参数true会导致无限递归从而引发栈溢出