### PR TITLE
adjust:  调整在环境初始化之前所返回的颜色值，以及允许预先设置窗口背景色

### DIFF
--- a/src/ege_graph.h
+++ b/src/ege_graph.h
@@ -43,4 +43,7 @@ int  swapbuffers();
 
 bool isinitialized();
 
+void replacePixels(PIMAGE pimg, color_t src, color_t dst, bool ignoreAlpha = false);
+
+
 }

--- a/src/ege_head.h
+++ b/src/ege_head.h
@@ -186,6 +186,7 @@ struct _graph_setting
     HWND         hwnd;
     std::wstring window_caption;
     HICON        window_hicon;
+    color_t      window_initial_color;
     int          exit_flag;
     int          exit_window;
     int          update_mark_count; // 更新标记
@@ -235,7 +236,8 @@ struct _graph_setting
     /* 函数用临时缓冲区 */
     DWORD g_t_buff[1024 * 8];
 
-    _graph_setting() { window_caption = EGE_TITLE_W; }
+public:
+    _graph_setting();
 };
 
 template <typename T> struct count_ptr

--- a/src/egegapi.cpp
+++ b/src/egegapi.cpp
@@ -689,21 +689,9 @@ color_t gettextcolor(PCIMAGE pimg)
 
 void setbkcolor(color_t color, PIMAGE pimg)
 {
-    PIMAGE img = CONVERT_IMAGE(pimg);
-
-    if (img && img->m_hDC) {
-        PDWORD p = img->m_pBuffer;
-        int size = img->m_width * img->m_height;
-        color_t col = img->m_bk_color;
-        img->m_bk_color = color;
-        SetBkColor(img->m_hDC, ARGBTOZBGR(color));
-        for (int n = 0; n < size; n++, p++) {
-            if (*p == col) {
-                *p = color;
-            }
-        }
-    }
-    CONVERT_IMAGE_END;
+    color_t oldBkColor = getbkcolor(pimg);
+    setbkcolor_f(color, pimg);
+    replacePixels(pimg, oldBkColor, color);
 }
 
 void setbkcolor_f(color_t color, PIMAGE pimg)

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -1078,4 +1078,29 @@ Gdiplus::Graphics* recreateGdiplusGraphics(HDC hdc, const Gdiplus::Graphics* old
     return newGraphics;
 }
 
+void replacePixels(PIMAGE pimg, color_t src, color_t dst, bool ignoreAlpha)
+{
+    PIMAGE img = CONVERT_IMAGE(pimg);
+    if (img && img->m_hDC) {
+        color_t* bufferBegin = img->getbuffer();
+        const color_t* bufferEnd =  bufferBegin + img->m_width * img->m_height;
+
+        if (ignoreAlpha) {
+            for (color_t* itor = bufferBegin; itor != bufferEnd; ++itor) {
+                if ((*itor & 0x00FFFFFF) == (src & 0x00FFFFFF)) {
+                    *itor = dst;
+                }
+            }
+        } else {
+            for (color_t* itor = bufferBegin; itor != bufferEnd; ++itor) {
+                if (*itor == src) {
+                    *itor = dst;
+                }
+            }
+        }
+    }
+
+    CONVERT_IMAGE_END
+}
+
 } // namespace ege

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -101,6 +101,12 @@ unsigned long getlogodatasize();
 
 DWORD WINAPI messageloopthread(LPVOID lpParameter);
 
+_graph_setting::_graph_setting()
+{
+    window_caption = EGE_TITLE_W;
+    window_initial_color = IMAGE::initial_bk_color;
+}
+
 /*private function*/
 static void ui_msg_process(EGEMSG& qmsg)
 {
@@ -873,31 +879,29 @@ DWORD WINAPI messageloopthread(LPVOID lpParameter)
 {
     _graph_setting* pg = (_graph_setting*)lpParameter;
     MSG             msg;
-    {
-        /* 执行应用程序初始化: */
-        if (!init_instance(pg->instance)) {
-            return 0xFFFFFFFF;
-        }
 
-        // 图形初始化
-        if (pg->dc == 0) {
-            graph_init(pg);
-        }
-
-        {
-            pg->mouse_show     = 0;
-            pg->exit_flag      = 0;
-            pg->use_force_exit = (g_initoption & INIT_NOFORCEEXIT ? false : true);
-            if (g_initoption & INIT_NOFORCEEXIT) {
-                SetCloseHandler(DefCloseHandler);
-            }
-            pg->close_manually = true;
-        }
-        {
-            pg->skip_timer_mark = false;
-            SetTimer(pg->hwnd, RENDER_TIMER_ID, 50, NULL);
-        }
+    /* 执行应用程序初始化: */
+    if (!init_instance(pg->instance)) {
+        return 0xFFFFFFFF;
     }
+
+    // 图形初始化
+    if (pg->dc == 0) {
+        graph_init(pg);
+    }
+
+    pg->mouse_show     = 0;
+    pg->exit_flag      = 0;
+    pg->use_force_exit = (g_initoption & INIT_NOFORCEEXIT ? false : true);
+
+    if (g_initoption & INIT_NOFORCEEXIT) {
+        SetCloseHandler(DefCloseHandler);
+    }
+
+    pg->close_manually = true;
+    pg->skip_timer_mark = false;
+    SetTimer(pg->hwnd, RENDER_TIMER_ID, 50, NULL);
+
     pg->has_init = true;
 
     while (!pg->exit_window) {
@@ -1057,7 +1061,7 @@ Gdiplus::Graphics* recreateGdiplusGraphics(HDC hdc, const Gdiplus::Graphics* old
         newGraphics->SetCompositingQuality(oldGraphics->GetCompositingQuality());
         newGraphics->SetTextContrast(oldGraphics->GetTextContrast());
 
-        /* 组合模式设置*/
+        /* 组合模式设置 */
         newGraphics->SetCompositingMode(oldGraphics->GetCompositingMode());
 
         /* 裁剪区域设置 */

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -60,6 +60,12 @@ void IMAGE::reset()
 #endif
 }
 
+/**
+ * 构造宽高为 width x height 的图像。
+ * @param width
+ * @param height
+ * @note: 创建的图像内容未定义，但经检测像素值均为 0。
+ */
 void IMAGE::construct(int width, int height)
 {
     HDC refDC = NULL;
@@ -79,9 +85,22 @@ void IMAGE::construct(int width, int height)
     }
 }
 
+/**
+ * 构造宽高为 width x height 的图像，将 color 设为背景色并以 color 填充整个图像。
+ * @param width
+ * @param height
+ * @param color
+ */
+void IMAGE::construct(int width, int height, color_t color)
+{
+    construct(width, height);
+    setbkcolor_f(color, this);
+    cleardevice(this);
+}
+
 IMAGE::IMAGE()
 {
-    construct(1, 1);
+    construct(1, 1, BLACK);
 }
 
 IMAGE::IMAGE(int width, int height)
@@ -94,6 +113,18 @@ IMAGE::IMAGE(int width, int height)
         height = 0;
     }
     construct(width, height);
+}
+
+IMAGE::IMAGE(int width, int height, color_t color)
+{
+    // 截止到 0
+    if (width < 0) {
+        width = 0;
+    }
+    if (height < 0) {
+        height = 0;
+    }
+    construct(width, height, color);
 }
 
 IMAGE::IMAGE(const IMAGE& img)
@@ -223,10 +254,11 @@ void IMAGE::initimage(HDC refDC, int width, int height)
 
 void IMAGE::setdefaultattribute()
 {
-    setcolor(LIGHTGRAY, this);
-    setbkcolor(BLACK, this);
-    SetBkMode(m_hDC, OPAQUE); // TRANSPARENT);
-    setfillstyle(SOLID_FILL, 0, this);
+    setlinecolor(initial_line_color, this);
+    settextcolor(initial_text_color, this);
+    setbkcolor_f(initial_bk_color, this);
+    SetBkMode(m_hDC, OPAQUE);
+    setfillstyle(SOLID_FILL, initial_fill_color, this);
     setlinestyle(PS_SOLID, 0, 1, this);
     settextjustify(LEFT_TEXT, TOP_TEXT, this);
     setfont(16, 0, "SimSun", this);
@@ -2774,7 +2806,7 @@ int gety(PCIMAGE pimg)
 
 PIMAGE newimage()
 {
-    return new IMAGE(1, 1);
+    return new IMAGE(1, 1, BLACK);
 }
 
 PIMAGE newimage(int width, int height)
@@ -2785,7 +2817,7 @@ PIMAGE newimage(int width, int height)
     if (height < 1) {
         height = 1;
     }
-    return new IMAGE(width, height);
+    return new IMAGE(width, height, BLACK);
 }
 
 void delimage(PCIMAGE pImg)

--- a/src/image.h
+++ b/src/image.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "ege_head.h"
+
 #include <windows.h>
 
 
@@ -10,6 +11,13 @@ namespace ege
 // 定义图像对象
 class IMAGE
 {
+public:
+    /* 初始颜色配置 */
+    static const color_t initial_line_color = LIGHTGRAY;
+    static const color_t initial_text_color = LIGHTGRAY;
+    static const color_t initial_fill_color = BLACK;
+    static const color_t initial_bk_color   = BLACK;
+private:
     int m_initflag;
 
 public:
@@ -32,6 +40,7 @@ private:
     bool m_aa;
     void initimage(HDC refDC, int width, int height);
     void construct(int width, int height);
+    void construct(int width, int height, color_t color);
     void setdefaultattribute();
     int  deleteimage();
     void reset();
@@ -53,12 +62,13 @@ private:
 public:
     IMAGE();
     IMAGE(int width, int height);
-    IMAGE(const IMAGE& img);            // 拷贝构造函数
-    IMAGE& operator=(const IMAGE& img); // 赋值运算符重载函数
+    IMAGE(int width, int height, color_t color);
+    IMAGE(const IMAGE& img);
+    IMAGE& operator=(const IMAGE& img);
     ~IMAGE();
+
     void gentexture(bool gen);
 
-public:
     HDC      getdc() const { return m_hDC; }
     int      getwidth() const { return m_width; }
     int      getheight() const { return m_height; }


### PR DESCRIPTION
- 在绘图环境初始化之前调用，getcolor(), getbkcolor(), getfillcolor() 将返回绘图环境初始化时所设置的默认颜色值。
- setbkcolor(), setbkcolor_f() 允许在绘图环境初始化之前调用，以预先设置窗口背景色，避免重复填充的同时减少屏幕闪烁