### PR TITLE
fix demo build error

### DIFF
--- a/tasks.sh
+++ b/tasks.sh
@@ -132,6 +132,9 @@ while [[ $# > 0 ]]; do
     --target)
         echo "set build target to $2"
         export BUILD_TARGET="$2"
+        if [[ $BUILD_TARGET == "demos" ]]; then
+            export CMAKE_CONFIG_DEFINE="$CMAKE_CONFIG_DEFINE -DEGE_BUILD_DEMO=ON"
+        fi
         shift
         shift
         ;;

--- a/utils/deploy.sh
+++ b/utils/deploy.sh
@@ -6,7 +6,7 @@ EGE_DIR=$(pwd)
 cd utils
 
 # 先执行一遍 release.sh
-./release.sh
+./release.sh || exit 1
 
 if [[ ! -d "xege_libs/.git" ]]; then
     git clone git@github.com:wysaid/xege.org.git xege_libs


### PR DESCRIPTION
CMake 里面新增了 EGE_BUILD_DEMO 选项， 但是根目录的 tasks.sh 没有做对应的适配， 导致 vscode 的指令无法正确执行。这里修正一下