### PR TITLE
fix:  修复调用 resizewindow 后图形出现偏移和被裁剪的问题

### DIFF
--- a/src/ege_graph.h
+++ b/src/ege_graph.h
@@ -43,6 +43,8 @@ Gdiplus::LineCap convertToGdiplusLineCap(line_cap_type linecap);
 
 Gdiplus::LineJoin convertToGdiplusLineJoin(line_join_type linejoin);
 
+int frameBufferCopy(HDC frontDC, const Point& frontPoint, HDC backDC, const Rect& rect);
+
 int  swapbuffers();
 
 bool isinitialized();

--- a/src/egegapi.cpp
+++ b/src/egegapi.cpp
@@ -1591,7 +1591,7 @@ void getviewport(int* left, int* top, int* right, int* bottom, int* clip, PCIMAG
         *bottom = img->m_vpt.bottom;
     }
     if (clip) {
-        *clip = img->m_vpt.clipflag;
+        *clip = img->m_enableclip;
     }
     CONVERT_IMAGE_END;
 }
@@ -1608,7 +1608,7 @@ void setviewport(int left, int top, int right, int bottom, int clip, PIMAGE pimg
     img->m_vpt.top = top;
     img->m_vpt.right = right;
     img->m_vpt.bottom = bottom;
-    img->m_vpt.clipflag = clip;
+    img->m_enableclip = clip;
 
     if (img->m_vpt.left < 0) {
         img->m_vpt.left = 0;
@@ -1624,7 +1624,7 @@ void setviewport(int left, int top, int right, int bottom, int clip, PIMAGE pimg
     }
 
     HRGN rgn = NULL;
-    if (img->m_vpt.clipflag) {
+    if (img->m_enableclip) {
         rgn = CreateRectRgn(img->m_vpt.left, img->m_vpt.top, img->m_vpt.right, img->m_vpt.bottom);
     } else {
         rgn = CreateRectRgn(0, 0, img->m_width, img->m_height);
@@ -1633,9 +1633,9 @@ void setviewport(int left, int top, int right, int bottom, int clip, PIMAGE pimg
     DeleteObject(rgn);
 
     Gdiplus::Graphics* graphics = img->getGraphics();
-    if (img->m_vpt.clipflag) {
-        const viewporttype& viewport = img->m_vpt;
-        Gdiplus::Rect clipRect(viewport.left, viewport.top, viewport.right - viewport.left, viewport.bottom - viewport.top);
+    if (img->m_enableclip) {
+        const Bound& viewport = img->m_vpt;
+        Gdiplus::Rect clipRect(viewport.x(), viewport.y(), viewport.width(), viewport.height());
         graphics->SetClip(clipRect);
     } else {
         graphics->ResetClip();

--- a/src/font.cpp
+++ b/src/font.cpp
@@ -155,7 +155,7 @@ void outtextrect(int x, int y, int w, int h, const wchar_t* text, PIMAGE pimg)
                 SelectClipRgn(img->m_hDC, oldClicRgn);
             } else {
                 HRGN rgn = NULL;
-                if (img->m_vpt.clipflag) {
+                if (img->m_enableclip) {
                     rgn = CreateRectRgn(img->m_vpt.left, img->m_vpt.top, img->m_vpt.right, img->m_vpt.bottom);
                 } else {
                     rgn = CreateRectRgn(0, 0, img->m_width, img->m_height);

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -189,7 +189,7 @@ int frameBufferCopy(HDC frontDC, const Point& frontPoint, HDC backDC, const Rect
         SetGraphicsMode(backDC, GM_COMPATIBLE);
     }
 
-    bool retColde = BitBlt(frontDC, frontPoint.x, frontPoint.y, rect.width, rect.height, backDC, rect.x, rect.y, SRCCOPY);
+    bool copyResult = BitBlt(frontDC, frontPoint.x, frontPoint.y, rect.width, rect.height, backDC, rect.x, rect.y, SRCCOPY);
 
     /* 恢复之前的设置 */
     SetViewportOrgEx(backDC, oldViewportOrigin.x, oldViewportOrigin.y, NULL);
@@ -198,10 +198,10 @@ int frameBufferCopy(HDC frontDC, const Point& frontPoint, HDC backDC, const Rect
 
     if (oldGraphicsMode == GM_ADVANCED) {
         SetGraphicsMode(backDC, oldGraphicsMode);
-        SetWorldTransform(backDC, &xform);;
+        SetWorldTransform(backDC, &xform);
     }
 
-    return retColde ? grOk : grError;
+    return copyResult ? grOk : grError;
 }
 
 int swapbuffers()

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -842,7 +842,7 @@ void IMAGE::putimage(PIMAGE imgDest, int xDest, int yDest, int widthDest, int he
 static void fix_rect_1size(PCIMAGE imgDest, PCIMAGE imgSrc, int* xDest, int* yDest,
         int* xSrc, int* ySrc, int* width, int* height)
 {
-    viewporttype vpt  = imgDest->m_vpt;
+    Bound vpt  = imgDest->m_vpt;
     Point srcPos(*xSrc, *ySrc);
     Point dstPos(*xDest + vpt.left, *yDest + vpt.top);
 
@@ -869,7 +869,7 @@ static void fix_rect_1size(PCIMAGE imgDest, PCIMAGE imgSrc, int* xDest, int* yDe
     /* 由视口区域计算绘制目标裁剪区域 */
     Bound srcClip(0, 0, imgSrc->m_width,  imgSrc->m_height);
     Bound dstClip(0, 0, imgDest->m_width, imgDest->m_height);
-    dstClip.intersect(Bound(vpt.left, vpt.top, vpt.right, vpt.bottom));
+    dstClip.intersect(vpt);
 
     srcBound.intersect(srcClip);
     dstBound.intersect(dstClip);
@@ -1040,8 +1040,8 @@ int IMAGE::putimage_alphablend(PIMAGE imgDest,    // handle to dest
             dll::AlphaBlend(img->m_hDC, xDest, yDest, widthDest, heightDest, imgSrc->m_hDC, xSrc, ySrc, widthSrc,
                 heightSrc, bf);
         } else {
-            const viewporttype& vptDest = img->m_vpt;
-            const viewporttype& vptSrc  = imgSrc->m_vpt;
+            const Bound& vptDest = img->m_vpt;
+            const Bound& vptSrc  = imgSrc->m_vpt;
             Rect drawDest(xDest + vptDest.left, yDest + vptDest.top, widthDest, heightDest);
             Rect drawSrc(xSrc + vptSrc.left, ySrc + vptSrc.top, widthSrc, heightSrc);
 
@@ -1237,13 +1237,13 @@ int IMAGE::putimage_withalpha(PIMAGE imgDest,    // handle to dest
         if (widthDest  <= 0) widthDest  = widthSrc;
         if (heightDest <= 0) heightDest = heightSrc;
 
-        const viewporttype& vptDest = imgDest->m_vpt;
-        const viewporttype& vptSrc  = imgSrc->m_vpt;
+        const Bound& vptDest = imgDest->m_vpt;
+        const Bound& vptSrc  = imgSrc->m_vpt;
         Rect drawDest(xDest + vptDest.left, yDest + vptDest.top, widthDest, heightDest);
         Rect drawSrc(xSrc + vptSrc.left, ySrc + vptSrc.top, widthSrc, heightSrc);
         Rect clipDest(0, 0, imgDest->m_width, imgDest->m_height);
 
-        if (vptDest.clipflag) {
+        if (imgDest->m_enableclip) {
             clipDest = Rect(vptDest.left, vptDest.top, vptDest.right - vptDest.left, vptDest.bottom - vptDest.top);
         }
         Gdiplus::GraphicsPath path;

--- a/src/image.h
+++ b/src/image.h
@@ -46,7 +46,8 @@ private:
     void reset();
 
 public:
-    viewporttype     m_vpt;
+    Bound            m_vpt;
+    bool             m_enableclip;
     textsettingstype m_texttype;
     line_style_type  m_linestyle;
     float            m_linewidth;

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -152,28 +152,22 @@ void EGEAPI resizewindow(int width, int height)
         height = parentH;
     }
 
-    int w = getwidth(), h = getheight();
-    if ((width == w && height == h)) {
+    if ((width == getwidth() && height == getheight())) {
         return;
     }
 
     setmode(TRUECOLORSIZE, width | (height << 16));
-    struct _graph_setting* pg = &graph_setting;
+    _graph_setting* pg = &graph_setting;
 
     for (int i = 0; i < BITMAP_PAGE_SIZE; ++i) {
         if (pg->img_page[i] != NULL) {
             resize(pg->img_page[i], width, height);
-
-            // 视口调整
-            int vleft, vtop, vright, vbottom, vclip;
-            getviewport(&vleft, &vtop, &vright, &vbottom, &vclip, pg->img_page[i]);
-            if (vleft == 0 && vtop == 0 && vright == w && vbottom == h) {
-                setviewport(0, 0, width, height, vclip, pg->img_page[i]);
-            }
         }
     }
-    // 窗口视口调整
-    window_setviewport(pg->base_x, pg->base_y, width, height);
+
+    /* 修改窗口宽高参数 */
+    pg->base_w = width;
+    pg->base_h = height;
 }
 
 int attachHWND(HWND hWnd)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new function to copy a specified region between device contexts, improving graphics buffer management.

- **Bug Fixes**
  - Improved handling of viewport and clipping regions when creating or resizing images, ensuring more reliable graphics rendering.
  - Enhanced consistency in image compositing and text drawing by unifying viewport and clipping logic.

- **Refactor**
  - Updated internal data structures and logic for viewport and clipping management to streamline graphics operations and improve maintainability.
  - Centralized GDI state management around graphics operations to maintain consistent coordinate transformations and clipping behavior.
  - Simplified window resizing logic by removing redundant viewport adjustments and directly updating window dimensions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->