### PR TITLE
adjust: 将 kbmsg, kbhit 在运行环境退出后的返回值由 -1 改为 0 以防止阻塞

### DIFF
--- a/demo/MandelbrotSetBase.cpp
+++ b/demo/MandelbrotSetBase.cpp
@@ -119,7 +119,7 @@ int main()
         bool isLDown = false;
         int selfx, selfy, seltx, selty; // 定义选区
 
-        while (kbhit() != -1)
+        while (is_run())
         {
             m = getmouse(); // 获取一条鼠标消息
 

--- a/demo/egetypegame.cpp
+++ b/demo/egetypegame.cpp
@@ -48,7 +48,7 @@ int main()
     setcolor(WHITE);
     setbkmode(TRANSPARENT);
     setrendermode(RENDER_MANUAL);
-    for ( ; kbhit() != -1; delay_fps(60))
+    for ( ; is_run(); delay_fps(60))
     {
         int bnew = 0, i;
         if (++t > 30) bnew = 1, t = 0;

--- a/demo/maintest.cpp
+++ b/demo/maintest.cpp
@@ -158,7 +158,7 @@ int main()
     edit.size(100, 18);
     edit.visible(true);
 
-    for (; kbhit() != -1; delay_fps(120)) {
+    for (; is_run(); delay_fps(120)) {
         // f.zorderup();
         {
             char str[20];

--- a/src/keyboard.cpp
+++ b/src/keyboard.cpp
@@ -99,7 +99,7 @@ int kbmsg()
 {
     struct _graph_setting* pg = &graph_setting;
     if (pg->exit_window) {
-        return grNoInitGraph;
+        return 0;
     }
     return peekallkey(pg, 3);
 }
@@ -108,7 +108,7 @@ int kbhitEx(int flag)
 {
     struct _graph_setting* pg = &graph_setting;
     if (pg->exit_window) {
-        return grNoInitGraph;
+        return 0;
     }
     if (flag == 0) {
         return peekkey(pg);
@@ -121,7 +121,7 @@ int getchEx(int flag)
 {
     struct _graph_setting* pg = &graph_setting;
     if (pg->exit_window) {
-        return grNoInitGraph;
+        return -1;
     }
 
     {


### PR DESCRIPTION
kbmsg() 和 kbhit() 通常用来判断是否有键盘消息和按键点击，如果返回 -1 则会导致判断错误，以这两个函数返回值为条件的循环甚至无法退出。并且 kbhit() != -1 可以用 is_run() 代替，应当简化函数功能。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Updated main event and game loop conditions in several demos to use a general running state check instead of keyboard input detection.
	- Adjusted keyboard handling functions to return different values when the application is exiting, improving consistency in exit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->