### PR TITLE
fix: 修复 resizewindow 后视口未进行调整的问题(#265 引入)

### DIFF
--- a/src/image.cpp
+++ b/src/image.cpp
@@ -249,7 +249,7 @@ void IMAGE::initimage(HDC refDC, int width, int height)
     m_height  = height;
     m_pBuffer = bmp_buf;
 
-    setviewport(0, 0, m_width, m_height, 1, this);
+    setviewport(0, 0, m_width, m_height, false, this);
 }
 
 void IMAGE::setdefaultattribute()


### PR DESCRIPTION
当调整图像大小时，需要满足视口区域和图像区域一致且不裁剪时才会令视口区域跟随图像调整。

创建图像时，视口应设置为区域和图像区域一致且不裁剪。



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted image initialization to update viewport clipping behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->